### PR TITLE
Add VideoPlayerControl and ViewModel with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### vi-009
+- Created VideoPlayerViewModel — binds to IVideoEngine, exposes PlayPause/Stop/SkipPrevious/SkipNext/ToggleMute/ToggleLoop commands, seek support with BeginSeek/EndSeek for slider dragging, position/duration text formatting, sibling video file navigation for skip prev/next, auto-advance on media end, FrameReady event forwarding
+- Created VideoPlayerControl.xaml — video player tab combining video display (WriteableBitmap rendered to Image) and transport controls bar; empty state with film reel icon and "Open a video file to begin" text; seek bar with elapsed/total time labels; skip prev/next, play/pause, stop buttons; volume slider with mute toggle; loop toggle
+- Created PlayerStyles.xaml — VS Code Dark Modern styled transport controls: TransportButtonStyle/PlayPauseButtonStyle (rounded hover), TransportToggleButtonStyle (accent when active), SeekSliderStyle (flat bar with accent fill, thumb visible on hover), VolumeSliderStyle (compact), TimeLabelStyle (Consolas monospace); icon geometries for play, pause, stop, skip prev/next, volume high/muted, loop, film reel
+- Created VideoPlayerControl.xaml.cs — WriteableBitmap frame rendering via BeginInvoke, auto-resize on resolution change, seek slider drag start/complete handlers, visual state switching between empty/media states
+- Added Video tab ("Player") — always the leftmost tab with play icon, no close button, active bottom accent line (AccentBrush), styled tab strip matching VS Code tab appearance
+- Wired double-click on video files in file explorer — TreeViewItem MouseDoubleClick EventSetter triggers playback; VideoFileDoubleClicked event added to FileExplorerPanel
+- Wired context menu "Play" action to trigger video playback
+- Registered VideoPlayerViewModel as singleton in DI container
+- Added InternalsVisibleTo for Vido.Tests in Vido.ViewModels
+- Added tests: VideoPlayerViewModelTests (38) — covering initial state (12), volume clamping (5), mute/loop toggle (4), no-op commands without media (2), engine event handling (5 — state, position, frame), FormatTime formatting (5 theory cases), GetAdjacentVideoFile (1), seek begin/end (2), dispose safety (2)
+- Total test count: 210 (all passing)
+
 ### vi-008
 - Created PlaybackState enum (None, Playing, Paused, Stopped) in Vido.Core.Playback
 - Created VideoMetadata model with full media properties (resolution, codecs, frame rate, bitrate, duration, file info, container format, audio details) and computed Resolution property

--- a/Context/TEST_PLANS/vi-009_test_plan.md
+++ b/Context/TEST_PLANS/vi-009_test_plan.md
@@ -1,0 +1,145 @@
+# vi-009 Test Plan: Video Player Tab — UI & Controls
+
+## Unit Tests (Automated)
+
+All automated tests are in `tests/Vido.Tests/`:
+
+### VideoPlayerViewModelTests (38 tests)
+
+**Initial State (12 tests)**
+- Initial state is PlaybackState.None
+- Initial position is TimeSpan.Zero
+- Initial duration is TimeSpan.Zero
+- Initial volume inherits from engine (75)
+- Initial isMuted inherits from engine (false)
+- Initial isLooping inherits from engine (false)
+- Initial hasMedia is false
+- Initial showPlayIcon is true
+- Initial positionText is "00:00"
+- Initial durationText is "00:00"
+- Initial currentFilePath is null
+- Initial currentMetadata is null
+
+**Volume (5 tests)**
+- SetVolume forwards to engine
+- Volume clamps: -10 → 0, 0 → 0, 50 → 50, 100 → 100, 150 → 100
+
+**Mute / Loop Toggles (4 tests)**
+- ToggleMute sets IsMuted true
+- ToggleMute forwards to engine
+- ToggleLoop sets IsLooping true
+- ToggleLoop forwards to engine
+
+**Commands Without Media (2 tests)**
+- PlayPause does nothing when no media
+- Stop does nothing when no media
+
+**Engine Event Handling (5 tests)**
+- StateChanged updates ViewModel state and ShowPlayIcon
+- StateChanged to Paused shows play icon
+- PositionChanged updates position and text
+- FrameReady raises ViewModel event
+- FormatTime formats correctly: 0→"00:00", 65→"01:05", 3599→"59:59", 3600→"1:00:00", 7261→"2:01:01"
+
+**Skip Navigation (1 test)**
+- GetAdjacentVideoFile returns null when no current file
+
+**Seek (2 tests)**
+- BeginSeek suppresses position updates
+- EndSeek resumes position updates
+
+**Dispose (2 tests)**
+- Dispose can be called multiple times safely
+- Dispose unsubscribes from engine events
+
+---
+
+## Manual Tests
+
+### Prerequisites
+1. Build the solution — FFmpeg native DLLs are provided automatically by the FFmpeg.LGPL NuGet package
+2. Open a folder containing video files
+
+### Test 1: Video Tab Always Present
+1. Launch the application
+2. **Expected**: "Player" tab is visible at the top-left of the editor area with a play icon
+3. **Expected**: Tab has bottom accent line (blue)
+4. **Expected**: Tab cannot be closed (no close button)
+
+### Test 2: Empty State
+1. Launch the application without loading any video
+2. **Expected**: Video area shows film reel icon and "Open a video file to begin" centered text
+3. **Expected**: Transport controls bar is visible at the bottom
+
+### Test 3: Load Video via Double-Click
+1. Open a folder containing video files
+2. Double-click a video file in the file explorer
+3. **Expected**: Video begins playing in the player tab
+4. **Expected**: Empty state text disappears, video frames render
+5. **Expected**: Seek bar shows position progressing, time labels update
+
+### Test 4: Load Video via Context Menu
+1. Right-click a video file in the file explorer
+2. Click "Play" from the context menu
+3. **Expected**: Video loads and begins playing
+
+### Test 5: Transport Controls
+1. Load a video file
+2. Click the Pause button (⏸) — **Expected**: Video pauses, button changes to Play (▶)
+3. Click the Play button (▶) — **Expected**: Video resumes
+4. Click the Stop button (⏹) — **Expected**: Video stops, position resets to 00:00
+5. Play again — **Expected**: Video plays from the beginning
+
+### Test 6: Seek Bar
+1. Load a video file and let it play
+2. Drag the seek slider to a different position
+3. **Expected**: Video seeks to the new position
+4. **Expected**: Position time label updates
+5. **Expected**: Slider doesn't fight with playback while dragging
+
+### Test 7: Volume and Mute
+1. Load a video file with audio
+2. Drag the volume slider — **Expected**: Volume changes
+3. Click the mute button — **Expected**: Audio mutes, icon changes to muted
+4. Click the mute button again — **Expected**: Audio unmutes, icon restores
+
+### Test 8: Loop Toggle
+1. Load a short video file
+2. Click the loop button — **Expected**: Button highlights with accent color
+3. Let the video reach the end — **Expected**: Video loops back to the beginning
+4. Click the loop button again — **Expected**: Button returns to normal color
+
+### Test 9: Skip Previous / Next
+1. Open a folder with multiple video files
+2. Load a video file (not the first or last alphabetically)
+3. Click Skip Next (⏭) — **Expected**: Next video file (alphabetically) loads and plays
+4. Click Skip Previous (⏮) — **Expected**: Previous video file loads and plays
+5. Navigate to the first file — **Expected**: Skip Previous does nothing
+6. Navigate to the last file — **Expected**: Skip Next does nothing
+
+### Test 10: Auto-Advance on End (Non-Loop)
+1. Ensure loop is OFF
+2. Play a short video file that is not the last in the folder
+3. Let it play to the end
+4. **Expected**: Next video file (alphabetically) loads and plays automatically
+
+### Test 11: Non-Video Files
+1. Double-click a non-video file (e.g., .txt) — **Expected**: Nothing happens
+2. Double-click a hidden video file — **Expected**: Nothing happens
+
+---
+
+## Regression Tests
+
+### Test R1: Existing Functionality Unaffected
+1. Launch the application
+2. Open a folder via File > Open Folder
+3. Expand directories in file explorer
+4. Right-click files — verify context menus work
+5. Toggle Show Hidden Files — verify hidden behavior
+6. Close folder — verify cleanup
+7. **Expected**: All existing vi-001 through vi-008 functionality works normally
+
+### Test R2: Build and Test Suite
+1. Run `dotnet build` — **Expected**: 0 errors, 0 warnings
+2. Run `dotnet test` — **Expected**: 210 tests passing, 0 failures

--- a/src/Vido.App/App.xaml.cs
+++ b/src/Vido.App/App.xaml.cs
@@ -83,6 +83,7 @@ public partial class App : Application
 
         // ViewModels
         services.AddSingleton<FileExplorerViewModel>();
+        services.AddSingleton<VideoPlayerViewModel>();
 
         // Windows
         services.AddSingleton<MainWindow>();

--- a/src/Vido.Core/Playback/IVideoEngine.cs
+++ b/src/Vido.Core/Playback/IVideoEngine.cs
@@ -61,4 +61,7 @@ public interface IVideoEngine : IDisposable
 
     /// <summary>Fires when the media reaches the end (before looping, if enabled).</summary>
     event Action? MediaEnded;
+
+    /// <summary>Fires after a seek operation has completed on the decode thread.</summary>
+    event Action? SeekCompleted;
 }

--- a/src/Vido.Services/Video/AudioRenderer.cs
+++ b/src/Vido.Services/Video/AudioRenderer.cs
@@ -10,7 +10,6 @@ internal sealed class AudioRenderer : IDisposable
 {
     private WasapiOut? _waveOut;
     private BufferedWaveProvider? _waveProvider;
-    private WaveFormat? _waveFormat;
     private bool _disposed;
     private float _volume = 1.0f;
     private bool _isMuted;
@@ -52,8 +51,8 @@ internal sealed class AudioRenderer : IDisposable
         Cleanup();
 
         // Use IEEE float samples (32-bit) — this is what swresample outputs
-        _waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
-        _waveProvider = new BufferedWaveProvider(_waveFormat)
+        var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+        _waveProvider = new BufferedWaveProvider(waveFormat)
         {
             // Buffer up to 1 second of audio — prevents underruns while limiting latency
             BufferLength = sampleRate * channels * sizeof(float),
@@ -148,7 +147,6 @@ internal sealed class AudioRenderer : IDisposable
         _waveOut?.Dispose();
         _waveOut = null;
         _waveProvider = null;
-        _waveFormat = null;
     }
 
     public void Dispose()

--- a/src/Vido.Services/Video/FFmpegVideoEngine.cs
+++ b/src/Vido.Services/Video/FFmpegVideoEngine.cs
@@ -1,5 +1,4 @@
-using System.Collections.Concurrent;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using FFmpeg.AutoGen.Abstractions;
 using Vido.Core.Logging;
@@ -35,12 +34,8 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
 
     // ── Threading ──
     private Thread? _decodeThread;
-    private readonly CancellationTokenSource _decodeCts = new();
+    private CancellationTokenSource _decodeCts = new();
     private readonly ManualResetEventSlim _pauseEvent = new(true);
-    private readonly ConcurrentQueue<FrameData> _videoFrameQueue = new();
-    private readonly ConcurrentQueue<byte[]> _audioSampleQueue = new();
-    private const int MaxVideoQueueSize = 8;
-    private const int MaxAudioQueueSize = 16;
 
     // ── Timing ──
     private readonly Stopwatch _playbackClock = new();
@@ -57,7 +52,25 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     private VideoMetadata? _currentMetadata;
     private bool _disposed;
     private readonly object _stateLock = new();
-    private volatile bool _isSeeking;
+
+    // ── Thread-safe seek ──
+    // Seek targets are posted here and consumed by the decode thread so that
+    // all codec access (send_packet, receive_frame, flush_buffers) happens
+    // on a single thread, avoiding the FFmpeg pthread_frame async_lock assertion.
+    private long _pendingSeekTicks = long.MinValue;
+    private const long NoSeekPending = long.MinValue;
+
+    // Generation counter incremented on each seek request. Frames decoded under
+    // an older generation are discarded, preventing stale frames from rendering
+    // at high speed between Seek() and SeekInternal().
+    private volatile uint _seekGeneration;
+
+    // After a seek, avformat_seek_file lands on the nearest keyframe BEFORE the
+    // target. Frames from that keyframe up to the target must be decoded (for
+    // codec reference) but NOT rendered — this is "silent preroll."
+    // _prerollTargetPts holds the seek target; frames with PTS below it are
+    // decoded silently. Set to -1 when no preroll is active.
+    private long _prerollTargetPts = -1;
 
     public FFmpegVideoEngine(ILogService logService)
     {
@@ -125,6 +138,7 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     public event Action<PlaybackState>? StateChanged;
     public event Action<FrameData>? FrameReady;
     public event Action? MediaEnded;
+    public event Action? SeekCompleted;
 
     // ── Commands ──
 
@@ -198,7 +212,19 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         if (State == PlaybackState.None) return;
 
         StopPositionTimer();
+
+        // Cancel and join the decode thread so it stops accessing codecs.
+        _decodeCts.Cancel();
         _pauseEvent.Set(); // Unblock decode thread so it can exit
+        _decodeThread?.Join(TimeSpan.FromSeconds(2));
+        _decodeThread = null;
+
+        // Reset CTS for the next Play() call.
+        _decodeCts.Dispose();
+        _decodeCts = new CancellationTokenSource();
+
+        // Discard any pending seek that was never processed.
+        Interlocked.Exchange(ref _pendingSeekTicks, NoSeekPending);
 
         _audioRenderer.Stop();
         _playbackClock.Stop();
@@ -206,17 +232,30 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         Position = TimeSpan.Zero;
         _clockOffset = TimeSpan.Zero;
 
-        // Clear queues
-        while (_videoFrameQueue.TryDequeue(out _)) { }
-        while (_audioSampleQueue.TryDequeue(out _)) { }
-
         State = PlaybackState.Stopped;
     }
 
     public void Seek(TimeSpan position)
     {
         if (State == PlaybackState.None) return;
-        SeekInternal(position);
+
+        // Increment generation so the decode thread discards any in-flight
+        // frames from before this seek. This is the key to preventing the
+        // speed-up artifact — stale frames are never rendered.
+        unchecked { _seekGeneration++; }
+
+        // Update position for the UI (position timer / slider) but do NOT
+        // reset the playback clock. The clock stays at the old position so
+        // WaitForPresentationTime keeps frames paced normally until
+        // SeekInternal runs on the decode thread and resets the clock there.
+        Position = position;
+        PositionChanged?.Invoke(position);
+
+        // Post the seek target for the decode thread to process.
+        Interlocked.Exchange(ref _pendingSeekTicks, position.Ticks);
+
+        // Wake the decode thread if it's blocked on the pause gate.
+        _pauseEvent.Set();
     }
 
     // ── Internal Implementation ──
@@ -401,25 +440,39 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
                 // Respect pause
                 _pauseEvent.Wait(_decodeCts.Token);
 
-                if (_isSeeking)
+                // Process any pending seek on this thread so all codec access
+                // (send_packet / receive_frame / flush_buffers) is single-threaded.
+                var seekTicks = Interlocked.Exchange(ref _pendingSeekTicks, NoSeekPending);
+                if (seekTicks != NoSeekPending)
                 {
-                    Thread.Sleep(1);
+                    SeekInternal(TimeSpan.FromTicks(seekTicks));
+                    SeekCompleted?.Invoke();
+
+                    // If we're paused, re-block so we wait again at the top.
+                    if (State == PlaybackState.Paused)
+                        _pauseEvent.Reset();
+
                     continue;
                 }
 
-                // Throttle if queues are full
-                if (_videoFrameQueue.Count >= MaxVideoQueueSize)
-                {
-                    Thread.Sleep(1);
-                    continue;
-                }
+                // Capture generation BEFORE reading the packet. If a seek arrives
+                // between here and DecodeVideoPacket, the generation mismatch
+                // will cause the stale packet's frames to be discarded.
+                var gen = _seekGeneration;
 
                 var readResult = ffmpeg.av_read_frame(_formatContext, packet);
                 if (readResult < 0)
                 {
-                    // End of file or error
+                    // End of file
                     if (readResult == ffmpeg.AVERROR_EOF)
                     {
+                        if (_isLooping)
+                        {
+                            // Seek back to beginning and keep decoding
+                            SeekInternal(TimeSpan.Zero);
+                            continue;
+                        }
+
                         HandleMediaEnded();
                     }
                     break;
@@ -429,7 +482,7 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
                 {
                     if (packet->stream_index == _videoStreamIndex)
                     {
-                        DecodeVideoPacket(packet, frame);
+                        DecodeVideoPacket(packet, frame, gen);
                     }
                     else if (packet->stream_index == _audioStreamIndex)
                     {
@@ -457,13 +510,38 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         }
     }
 
-    private void DecodeVideoPacket(AVPacket* packet, AVFrame* frame)
+    private void DecodeVideoPacket(AVPacket* packet, AVFrame* frame, uint generation)
     {
+        // If a seek arrived since this packet was read, discard immediately.
+        if (_seekGeneration != generation) return;
+
         var result = ffmpeg.avcodec_send_packet(_videoCodecContext, packet);
         if (result < 0) return;
 
         while (ffmpeg.avcodec_receive_frame(_videoCodecContext, frame) == 0)
         {
+            // If a seek was requested since we started, discard stale frames.
+            if (_seekGeneration != generation)
+            {
+                ffmpeg.av_frame_unref(frame);
+                return;
+            }
+
+            // Silent preroll: after a seek, avformat_seek_file lands at a keyframe
+            // BEFORE the target. We must decode these frames (B-frame references)
+            // but not render them. Once we reach the target PTS, clear the flag.
+            var prerollTarget = _prerollTargetPts;
+            if (prerollTarget >= 0)
+            {
+                if (frame->best_effort_timestamp < prerollTarget)
+                {
+                    ffmpeg.av_frame_unref(frame);
+                    continue; // Decode next frame silently
+                }
+                // Reached or passed the target -- end preroll
+                _prerollTargetPts = -1;
+            }
+
             // Configure frame converter on first frame or format change
             _frameConverter.Configure(
                 frame->width, frame->height,
@@ -475,9 +553,16 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
             var frameData = _frameConverter.Convert(frame, pts);
             if (frameData != null)
             {
-                // Wait for the correct display time
-                WaitForPresentationTime(pts);
-                _videoFrameQueue.Enqueue(frameData);
+                // Wait for the correct display time, but abort if a seek arrives
+                WaitForPresentationTime(pts, generation);
+
+                // Check generation after the wait
+                if (_seekGeneration != generation)
+                {
+                    ffmpeg.av_frame_unref(frame);
+                    return;
+                }
+
                 FrameReady?.Invoke(frameData);
             }
 
@@ -530,7 +615,7 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         return TimeSpan.FromSeconds(seconds);
     }
 
-    private void WaitForPresentationTime(TimeSpan pts)
+    private void WaitForPresentationTime(TimeSpan pts, uint generation)
     {
         if (State != PlaybackState.Playing) return;
 
@@ -539,11 +624,14 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
 
         if (delay > TimeSpan.FromMilliseconds(1) && delay < TimeSpan.FromSeconds(2))
         {
-            // Use SpinWait for short waits, Thread.Sleep for longer
-            if (delay.TotalMilliseconds < 5)
-                Thread.SpinWait((int)(delay.TotalMilliseconds * 1000));
-            else
-                Thread.Sleep(delay - TimeSpan.FromMilliseconds(1));
+            // Break the wait into small chunks so we can abort on seek
+            var end = Stopwatch.GetTimestamp() + (long)(delay.TotalSeconds * Stopwatch.Frequency);
+            while (Stopwatch.GetTimestamp() < end)
+            {
+                if (_seekGeneration != generation || _decodeCts.IsCancellationRequested)
+                    return;
+                Thread.Sleep(1);
+            }
         }
     }
 
@@ -577,36 +665,32 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     {
         if (_formatContext == null) return;
 
-        _isSeeking = true;
+        _audioRenderer.Flush();
 
-        try
+        // Seek to the target position (lands on nearest keyframe BEFORE target)
+        var timestamp = (long)(position.TotalSeconds * ffmpeg.AV_TIME_BASE);
+        ffmpeg.avformat_seek_file(_formatContext, -1, long.MinValue, timestamp, long.MaxValue, 0);
+
+        // Flush codec buffers
+        if (_videoCodecContext != null)
+            ffmpeg.avcodec_flush_buffers(_videoCodecContext);
+        if (_audioCodecContext != null)
+            ffmpeg.avcodec_flush_buffers(_audioCodecContext);
+
+        // Enable silent preroll: frames from the keyframe up to the target are
+        // decoded (for codec reference / B-frames) but not rendered.
+        if (_videoStream != null)
         {
-            // Clear queues
-            while (_videoFrameQueue.TryDequeue(out _)) { }
-            while (_audioSampleQueue.TryDequeue(out _)) { }
-            _audioRenderer.Flush();
-
-            // Seek to the target position
-            var timestamp = (long)(position.TotalSeconds * ffmpeg.AV_TIME_BASE);
-            ffmpeg.avformat_seek_file(_formatContext, -1, long.MinValue, timestamp, long.MaxValue, 0);
-
-            // Flush codec buffers
-            if (_videoCodecContext != null)
-                ffmpeg.avcodec_flush_buffers(_videoCodecContext);
-            if (_audioCodecContext != null)
-                ffmpeg.avcodec_flush_buffers(_audioCodecContext);
-
-            Position = position;
-            _clockOffset = position;
-            if (_playbackClock.IsRunning)
-                _playbackClock.Restart();
-
-            PositionChanged?.Invoke(position);
+            var tb = _videoStream->time_base;
+            _prerollTargetPts = (long)(position.TotalSeconds * tb.den / tb.num);
         }
-        finally
-        {
-            _isSeeking = false;
-        }
+
+        Position = position;
+        _clockOffset = position;
+        if (_playbackClock.IsRunning)
+            _playbackClock.Restart();
+
+        PositionChanged?.Invoke(position);
     }
 
     // ── End of Media ──
@@ -614,13 +698,6 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     private void HandleMediaEnded()
     {
         MediaEnded?.Invoke();
-
-        if (_isLooping)
-        {
-            SeekInternal(TimeSpan.Zero);
-            return;
-        }
-
         Stop();
     }
 
@@ -632,6 +709,10 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         _decodeCts.Cancel();
         _pauseEvent.Set();
         _decodeThread?.Join(TimeSpan.FromSeconds(2));
+
+        // Reset CTS so the next decode thread gets a fresh, non-cancelled token
+        _decodeCts.Dispose();
+        _decodeCts = new CancellationTokenSource();
 
         StopPositionTimer();
         _audioRenderer.Stop();
@@ -669,10 +750,6 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         _audioStreamIndex = -1;
         _videoStream = null;
         _audioStream = null;
-
-        // Clear queues
-        while (_videoFrameQueue.TryDequeue(out _)) { }
-        while (_audioSampleQueue.TryDequeue(out _)) { }
 
         _currentMetadata = null;
         Duration = TimeSpan.Zero;

--- a/src/Vido.ViewModels/VideoPlayerViewModel.cs
+++ b/src/Vido.ViewModels/VideoPlayerViewModel.cs
@@ -1,0 +1,485 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Vido.Core.FileSystem;
+using Vido.Core.Playback;
+
+namespace Vido.ViewModels;
+
+/// <summary>
+/// ViewModel for the video player tab. Binds to <see cref="IVideoEngine"/>
+/// and exposes commands for transport controls, skip prev/next, and frame display.
+/// </summary>
+public partial class VideoPlayerViewModel : ObservableObject, IDisposable
+{
+    private readonly IVideoEngine _engine;
+    private bool _disposed;
+    private bool _isSeeking;
+
+    // ── Observable state ──
+
+    /// <summary>Current playback state.</summary>
+    [ObservableProperty]
+    private PlaybackState _state;
+
+    /// <summary>Current playback position.</summary>
+    [ObservableProperty]
+    private TimeSpan _position;
+
+    /// <summary>Total duration of the loaded media.</summary>
+    [ObservableProperty]
+    private TimeSpan _duration;
+
+    /// <summary>Volume level (0–100).</summary>
+    [ObservableProperty]
+    private int _volume;
+
+    /// <summary>Whether audio is muted.</summary>
+    [ObservableProperty]
+    private bool _isMuted;
+
+    /// <summary>Whether playback loops at end.</summary>
+    [ObservableProperty]
+    private bool _isLooping;
+
+    /// <summary>Whether shuffle mode is active.</summary>
+    [ObservableProperty]
+    private bool _isShuffling;
+
+    /// <summary>Whether a video file is currently loaded.</summary>
+    [ObservableProperty]
+    private bool _hasMedia;
+
+    /// <summary>Metadata of the currently loaded video.</summary>
+    [ObservableProperty]
+    private VideoMetadata? _currentMetadata;
+
+    /// <summary>Display text for the current position (e.g. "01:23").</summary>
+    [ObservableProperty]
+    private string _positionText = "00:00";
+
+    /// <summary>Display text for the total duration (e.g. "05:47").</summary>
+    [ObservableProperty]
+    private string _durationText = "00:00";
+
+    /// <summary>
+    /// Seek position as a value from 0 to 1000 for slider binding.
+    /// </summary>
+    [ObservableProperty]
+    private double _seekPosition;
+
+    /// <summary>True when the play button icon should appear (i.e. not currently playing).</summary>
+    [ObservableProperty]
+    private bool _showPlayIcon = true;
+
+    /// <summary>
+    /// Path of the currently loaded video file, or null if none.
+    /// Used for skip prev/next logic.
+    /// </summary>
+    [ObservableProperty]
+    private string? _currentFilePath;
+
+    /// <summary>
+    /// Ordered list of all video files under the explorer root.
+    /// Populated when the explorer root changes or a file is loaded.
+    /// </summary>
+    private List<string> _siblingVideoFiles = [];
+
+    /// <summary>
+    /// The root folder path from the file explorer. Used to scan all nested video files.
+    /// </summary>
+    private string? _explorerRootPath;
+
+    /// <summary>
+    /// Pre-shuffled playlist with no repeats. Built when shuffle is toggled on.
+    /// Index tracks current position in the shuffle order.
+    /// </summary>
+    private List<string> _shufflePlaylist = [];
+    private int _shuffleIndex = -1;
+
+    /// <summary>
+    /// Fired when a decoded frame is ready for display.
+    /// The view subscribes to this to write pixels into a WriteableBitmap.
+    /// </summary>
+    public event Action<FrameData>? FrameReady;
+
+    public VideoPlayerViewModel(IVideoEngine engine)
+    {
+        _engine = engine;
+        Volume = _engine.Volume;
+        IsMuted = _engine.IsMuted;
+        IsLooping = _engine.IsLooping;
+
+        _engine.StateChanged += OnEngineStateChanged;
+        _engine.PositionChanged += OnEnginePositionChanged;
+        _engine.FrameReady += OnEngineFrameReady;
+        _engine.MediaEnded += OnEngineMediaEnded;
+    }
+
+    // ── Engine event handlers ──
+
+    private void OnEngineStateChanged(PlaybackState newState)
+    {
+        State = newState;
+        ShowPlayIcon = newState != PlaybackState.Playing;
+    }
+
+    private void OnEnginePositionChanged(TimeSpan position)
+    {
+        if (_isSeeking) return;
+
+        Position = position;
+        PositionText = FormatTime(position);
+
+        if (Duration.TotalSeconds > 0)
+            SeekPosition = position.TotalSeconds / Duration.TotalSeconds * 1000.0;
+    }
+
+    private void OnEngineFrameReady(FrameData frame)
+    {
+        // Always forward frames — the engine handles stale frame prevention
+        // via the seek generation counter and silent preroll.
+        FrameReady?.Invoke(frame);
+    }
+
+    private void OnEngineMediaEnded()
+    {
+        // If looping the current file, the engine already handles it.
+        // Otherwise, advance to next file (respecting shuffle mode).
+        if (!IsLooping)
+        {
+            var next = GetNextFile();
+            if (next is not null)
+            {
+                _ = LoadAndPlayAsync(next);
+            }
+        }
+    }
+
+
+    // ── Commands ──
+
+    /// <summary>
+    /// Loads a video file and begins playback.
+    /// </summary>
+    public async Task LoadAndPlayAsync(string filePath)
+    {
+        await _engine.LoadAsync(filePath);
+
+        CurrentFilePath = filePath;
+        Duration = _engine.Duration;
+        DurationText = FormatTime(Duration);
+        CurrentMetadata = _engine.CurrentMetadata;
+        HasMedia = true;
+        Position = TimeSpan.Zero;
+        PositionText = "00:00";
+        SeekPosition = 0;
+
+        // Build sibling video file list for skip prev/next
+        BuildSiblingList(filePath);
+
+        // Sync shuffle index to the file we just loaded
+        if (IsShuffling && _shufflePlaylist.Count > 0)
+        {
+            _shuffleIndex = _shufflePlaylist.FindIndex(
+                f => string.Equals(f, filePath, StringComparison.OrdinalIgnoreCase));
+        }
+
+        _engine.Play();
+    }
+
+    /// <summary>Toggles between play and pause.</summary>
+    [RelayCommand]
+    public void PlayPause()
+    {
+        if (!HasMedia) return;
+
+        if (State == PlaybackState.Playing)
+            _engine.Pause();
+        else
+            _engine.Play();
+    }
+
+    /// <summary>Stops playback and resets position.</summary>
+    [RelayCommand]
+    public void Stop()
+    {
+        if (!HasMedia) return;
+        _engine.Stop();
+        HasMedia = false;
+        CurrentMetadata = null;
+        CurrentFilePath = null;
+        Position = TimeSpan.Zero;
+        Duration = TimeSpan.Zero;
+        PositionText = "00:00";
+        DurationText = "00:00";
+        SeekPosition = 0;
+    }
+
+    /// <summary>Skips to the previous video file in the folder (wraps around).</summary>
+    [RelayCommand]
+    public async Task SkipPrevious()
+    {
+        var prev = IsShuffling ? GetShuffleFile(-1) : GetAdjacentVideoFile(-1);
+        if (prev is not null)
+            await LoadAndPlayAsync(prev);
+    }
+
+    /// <summary>Skips to the next video file in the folder (wraps around).</summary>
+    [RelayCommand]
+    public async Task SkipNext()
+    {
+        var next = IsShuffling ? GetShuffleFile(1) : GetAdjacentVideoFile(1);
+        if (next is not null)
+            await LoadAndPlayAsync(next);
+    }
+
+    /// <summary>Toggles mute state.</summary>
+    [RelayCommand]
+    public void ToggleMute()
+    {
+        IsMuted = !IsMuted;
+    }
+
+    /// <summary>Toggles loop mode.</summary>
+    [RelayCommand]
+    public void ToggleLoop()
+    {
+        IsLooping = !IsLooping;
+    }
+
+    /// <summary>Toggles shuffle mode. Builds or clears the shuffle playlist.</summary>
+    [RelayCommand]
+    public void ToggleShuffle()
+    {
+        IsShuffling = !IsShuffling;
+    }
+
+    // ── Property change callbacks ──
+
+    partial void OnVolumeChanged(int value)
+    {
+        _engine.Volume = Math.Clamp(value, 0, 100);
+
+        // Any manual volume adjustment should unmute
+        if (IsMuted)
+            IsMuted = false;
+    }
+
+    partial void OnIsMutedChanged(bool value)
+    {
+        _engine.IsMuted = value;
+    }
+
+    partial void OnIsLoopingChanged(bool value)
+    {
+        _engine.IsLooping = value;
+    }
+
+    partial void OnIsShufflingChanged(bool value)
+    {
+        if (value)
+            BuildShufflePlaylist();
+        else
+            ClearShufflePlaylist();
+    }
+
+    // ── Seek support ──
+
+    /// <summary>
+    /// Suppresses engine position updates so the slider doesn't fight during drag.
+    /// Called on seek mouse-down.
+    /// </summary>
+    public void BeginSeek()
+    {
+        _isSeeking = true;
+    }
+
+    /// <summary>
+    /// Resumes engine position updates.
+    /// Called on seek mouse-up.
+    /// </summary>
+    public void EndSeek()
+    {
+        _isSeeking = false;
+    }
+
+    /// <summary>
+    /// Seeks the engine to the current slider position without changing _isSeeking state.
+    /// Called on each mouse-down click and on every mouse-move during drag.
+    /// </summary>
+    public void ApplySeek()
+    {
+        if (Duration.TotalSeconds > 0)
+        {
+            var target = TimeSpan.FromSeconds(SeekPosition / 1000.0 * Duration.TotalSeconds);
+            _engine.Seek(target);
+            Position = target;
+            PositionText = FormatTime(target);
+        }
+    }
+
+    /// <summary>
+    /// Sets the explorer root folder path. When set, the sibling video list
+    /// is rebuilt to include all video files recursively under this root.
+    /// Called from MainWindow when a folder is opened or closed.
+    /// </summary>
+    public void SetExplorerRoot(string? rootPath)
+    {
+        _explorerRootPath = rootPath;
+        RebuildSiblingList();
+
+        // Clear shuffle when the library changes
+        if (IsShuffling)
+        {
+            ClearShufflePlaylist();
+            BuildShufflePlaylist();
+        }
+    }
+
+    // ── Skip prev/next helpers ──
+
+    /// <summary>
+    /// Builds the sorted list of all video files under the explorer root recursively.
+    /// Falls back to the parent directory of the given file if no root is set.
+    /// </summary>
+    private void BuildSiblingList(string filePath)
+    {
+        // If there's no explorer root, use the file's parent folder as fallback
+        if (_explorerRootPath is null)
+        {
+            var dir = Path.GetDirectoryName(filePath);
+            if (dir is not null)
+                _explorerRootPath = dir;
+        }
+
+        RebuildSiblingList();
+    }
+
+    /// <summary>
+    /// Scans the explorer root (recursively) for all video files and sorts alphabetically.
+    /// </summary>
+    private void RebuildSiblingList()
+    {
+        if (_explorerRootPath is null || !Directory.Exists(_explorerRootPath))
+        {
+            _siblingVideoFiles = [];
+            return;
+        }
+
+        try
+        {
+            _siblingVideoFiles = Directory.EnumerateFiles(_explorerRootPath, "*.*", SearchOption.AllDirectories)
+                .Where(f => FileNode.VideoExtensions.Contains(Path.GetExtension(f)))
+                .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch
+        {
+            _siblingVideoFiles = [];
+        }
+    }
+
+    /// <summary>
+    /// Returns the video file at <paramref name="offset"/> positions relative
+    /// to the current file in the sibling list. Wraps around from end to beginning
+    /// and vice-versa.
+    /// </summary>
+    internal string? GetAdjacentVideoFile(int offset)
+    {
+        if (CurrentFilePath is null || _siblingVideoFiles.Count == 0)
+            return null;
+
+        var idx = _siblingVideoFiles.FindIndex(
+            f => string.Equals(f, CurrentFilePath, StringComparison.OrdinalIgnoreCase));
+
+        if (idx < 0) return null;
+
+        // Wrap around using modular arithmetic
+        var count = _siblingVideoFiles.Count;
+        var target = ((idx + offset) % count + count) % count;
+        return _siblingVideoFiles[target];
+    }
+
+    /// <summary>
+    /// Returns the next file to play (respecting shuffle mode).
+    /// Used by auto-advance on media end.
+    /// </summary>
+    internal string? GetNextFile()
+    {
+        return IsShuffling ? GetShuffleFile(1) : GetAdjacentVideoFile(1);
+    }
+
+    /// <summary>
+    /// Returns the file at <paramref name="offset"/> from the current shuffle index.
+    /// Wraps around the shuffle playlist.
+    /// </summary>
+    internal string? GetShuffleFile(int offset)
+    {
+        if (_shufflePlaylist.Count == 0) return null;
+
+        var count = _shufflePlaylist.Count;
+        var target = ((_shuffleIndex + offset) % count + count) % count;
+        return _shufflePlaylist[target];
+    }
+
+    /// <summary>
+    /// Builds a randomized playlist from the sibling video files with no duplicates.
+    /// The current file is placed at the start so the user continues from here.
+    /// </summary>
+    internal void BuildShufflePlaylist()
+    {
+        if (_siblingVideoFiles.Count == 0)
+        {
+            _shufflePlaylist = [];
+            _shuffleIndex = -1;
+            return;
+        }
+
+        var rng = new Random();
+        var remaining = _siblingVideoFiles
+            .Where(f => !string.Equals(f, CurrentFilePath, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(_ => rng.Next())
+            .ToList();
+
+        _shufflePlaylist = new List<string>(_siblingVideoFiles.Count);
+
+        // Current file first so skip-next goes to a random one
+        if (CurrentFilePath is not null)
+            _shufflePlaylist.Add(CurrentFilePath);
+
+        _shufflePlaylist.AddRange(remaining);
+        _shuffleIndex = 0;
+    }
+
+    /// <summary>
+    /// Clears the shuffle playlist.
+    /// </summary>
+    internal void ClearShufflePlaylist()
+    {
+        _shufflePlaylist = [];
+        _shuffleIndex = -1;
+    }
+
+    // ── Formatting ──
+
+    internal static string FormatTime(TimeSpan ts)
+    {
+        if (ts.TotalHours >= 1)
+            return ts.ToString(@"h\:mm\:ss");
+        return ts.ToString(@"mm\:ss");
+    }
+
+    // ── Cleanup ──
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _engine.StateChanged -= OnEngineStateChanged;
+        _engine.PositionChanged -= OnEnginePositionChanged;
+        _engine.FrameReady -= OnEngineFrameReady;
+        _engine.MediaEnded -= OnEngineMediaEnded;
+    }
+}

--- a/src/Vido.ViewModels/Vido.ViewModels.csproj
+++ b/src/Vido.ViewModels/Vido.ViewModels.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Vido.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
   </ItemGroup>
 

--- a/src/Vido.Views/Controls/PlayerStyles.xaml
+++ b/src/Vido.Views/Controls/PlayerStyles.xaml
@@ -1,0 +1,292 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="../Themes/Brushes.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <!-- ===== Transport button style (icon buttons in controls bar) ===== -->
+    <Style x:Key="TransportButtonStyle" TargetType="Button">
+        <Setter Property="Width" Value="32" />
+        <Setter Property="Height" Value="32" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryForegroundBrush}" />
+        <Setter Property="Padding" Value="6" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="Bd"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="Background"
+                                    Value="{DynamicResource HoverBackgroundBrush}" />
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource PrimaryForegroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Opacity" Value="0.35" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Large play/pause button -->
+    <Style x:Key="PlayPauseButtonStyle" TargetType="Button"
+           BasedOn="{StaticResource TransportButtonStyle}">
+        <Setter Property="Width" Value="36" />
+        <Setter Property="Height" Value="36" />
+    </Style>
+
+    <!-- Transport toggle button (loop, mute) -->
+    <Style x:Key="TransportToggleButtonStyle" TargetType="ToggleButton">
+        <Setter Property="Width" Value="28" />
+        <Setter Property="Height" Value="28" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryForegroundBrush}" />
+        <Setter Property="Padding" Value="5" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ToggleButton">
+                    <Border x:Name="Bd"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="4"
+                            Padding="{TemplateBinding Padding}">
+                        <ContentPresenter HorizontalAlignment="Center"
+                                          VerticalAlignment="Center" />
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsMouseOver" Value="True">
+                            <Setter TargetName="Bd" Property="Background"
+                                    Value="{DynamicResource HoverBackgroundBrush}" />
+                        </Trigger>
+                        <Trigger Property="IsChecked" Value="True">
+                            <Setter Property="Foreground"
+                                    Value="{DynamicResource AccentBrush}" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ===== Seek slider style (YouTube-like: grey track, blue accent fill) ===== -->
+
+    <!-- Filled portion before thumb (accent color) -->
+    <Style x:Key="SeekSliderDecreaseButton" TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Grid Background="Transparent">
+                        <Border Height="3" CornerRadius="1.5,0,0,1.5"
+                                Background="{DynamicResource AccentBrush}"
+                                VerticalAlignment="Center" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Unfilled portion after thumb (grey track) -->
+    <Style x:Key="SeekSliderIncreaseButton" TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Grid Background="Transparent">
+                        <Border Height="3" CornerRadius="0,1.5,1.5,0"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                VerticalAlignment="Center" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Seek thumb: invisible — interaction is handled via mouse capture on the track -->
+    <Style x:Key="SeekSliderThumb" TargetType="Thumb">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Width" Value="0" />
+        <Setter Property="Height" Value="18" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Grid Background="Transparent" Margin="-6,0,-6,0" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SeekSliderStyle" TargetType="Slider">
+        <Setter Property="Minimum" Value="0" />
+        <Setter Property="Maximum" Value="1000" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsSnapToTickEnabled" Value="False" />
+        <Setter Property="IsMoveToPointEnabled" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Slider">
+                    <Grid Height="18" VerticalAlignment="Center">
+                        <Track x:Name="PART_Track">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource SeekSliderDecreaseButton}" />
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource SeekSliderIncreaseButton}" />
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Style="{StaticResource SeekSliderThumb}" />
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ===== Volume slider style (compact) ===== -->
+    <!-- Volume slider: filled portion (left of thumb position) -->
+    <Style x:Key="VolumeDecreaseButton" TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Grid Background="Transparent">
+                        <Border Height="3" CornerRadius="1.5,0,0,1.5"
+                                Background="{DynamicResource PrimaryForegroundBrush}"
+                                VerticalAlignment="Center" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Volume slider: unfilled portion (right of thumb position) -->
+    <Style x:Key="VolumeIncreaseButton" TargetType="RepeatButton">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="RepeatButton">
+                    <Grid Background="Transparent">
+                        <Border Height="3" CornerRadius="0,1.5,1.5,0"
+                                Background="{DynamicResource InputBackgroundBrush}"
+                                VerticalAlignment="Center" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Volume thumb: invisible — all interaction is via click/drag on the track bar -->
+    <Style x:Key="VolumeSliderThumb" TargetType="Thumb">
+        <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="Width" Value="0" />
+        <Setter Property="Height" Value="14" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Thumb">
+                    <Grid Background="Transparent" Margin="-5,0,-5,0" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="VolumeSliderStyle" TargetType="Slider">
+        <Setter Property="Minimum" Value="0" />
+        <Setter Property="Maximum" Value="100" />
+        <Setter Property="Width" Value="80" />
+        <Setter Property="Focusable" Value="False" />
+        <Setter Property="IsSnapToTickEnabled" Value="False" />
+        <Setter Property="IsMoveToPointEnabled" Value="True" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Slider">
+                    <Grid Height="20" VerticalAlignment="Center" Background="Transparent">
+                        <Track x:Name="PART_Track">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource VolumeDecreaseButton}" />
+                            </Track.DecreaseRepeatButton>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton Style="{StaticResource VolumeIncreaseButton}" />
+                            </Track.IncreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Style="{StaticResource VolumeSliderThumb}" />
+                            </Track.Thumb>
+                        </Track>
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- ===== Time label style ===== -->
+    <Style x:Key="TimeLabelStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="Consolas" />
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="Foreground" Value="{DynamicResource SecondaryForegroundBrush}" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <!-- ===== Tab strip styles ===== -->
+    <Style x:Key="EditorTabStyle" TargetType="Border">
+        <Setter Property="Height" Value="35" />
+        <Setter Property="Padding" Value="12,0" />
+        <Setter Property="Background" Value="{DynamicResource TabInactiveBackgroundBrush}" />
+        <Setter Property="Cursor" Value="Hand" />
+    </Style>
+
+    <!-- ===== Icon geometries for transport controls ===== -->
+
+    <!-- Play triangle -->
+    <StreamGeometry x:Key="PlayIconGeometry">M 4,2 L 4,18 L 18,10 Z</StreamGeometry>
+
+    <!-- Pause bars -->
+    <StreamGeometry x:Key="PauseIconGeometry">M 4,2 L 4,18 L 8,18 L 8,2 Z M 12,2 L 12,18 L 16,18 L 16,2 Z</StreamGeometry>
+
+    <!-- Stop square -->
+    <StreamGeometry x:Key="StopIconGeometry">M 3,3 L 3,17 L 17,17 L 17,3 Z</StreamGeometry>
+
+    <!-- Skip previous -->
+    <StreamGeometry x:Key="SkipPreviousGeometry">M 3,3 L 3,17 L 5,17 L 5,3 Z M 6,10 L 17,3 L 17,17 Z</StreamGeometry>
+
+    <!-- Skip next -->
+    <StreamGeometry x:Key="SkipNextGeometry">M 3,3 L 3,17 L 14,10 Z M 15,3 L 15,17 L 17,17 L 17,3 Z</StreamGeometry>
+
+    <!-- Volume high (speaker with waves) -->
+    <StreamGeometry x:Key="VolumeHighGeometry">M 2,7 L 2,13 L 5,13 L 10,17 L 10,3 L 5,7 Z M 13,5 Q 17,10 13,15 M 12,8 Q 14,10 12,12</StreamGeometry>
+
+    <!-- Volume muted (speaker with X) -->
+    <StreamGeometry x:Key="VolumeMutedGeometry">M 2,7 L 2,13 L 5,13 L 10,17 L 10,3 L 5,7 Z M 13,7 L 18,13 M 18,7 L 13,13</StreamGeometry>
+
+    <!-- Loop arrows -->
+    <StreamGeometry x:Key="LoopIconGeometry">M 6,4 L 16,4 Q 19,4 19,7 L 19,9 L 17,7 M 19,9 L 21,7 M 14,16 L 4,16 Q 1,16 1,13 L 1,11 L 3,13 M 1,11 L -1,13</StreamGeometry>
+
+    <!-- Shuffle icon (crossed arrows) -->
+    <StreamGeometry x:Key="ShuffleIconGeometry">M 3,5 L 14,15 M 14,15 L 14,12 M 14,15 L 17,15 M 3,15 L 14,5 M 14,5 L 14,8 M 14,5 L 17,5</StreamGeometry>
+
+    <!-- Film reel icon (for empty state) -->
+    <StreamGeometry x:Key="FilmReelGeometry">M 3,2 L 3,18 L 17,18 L 17,2 Z M 5,5 L 7,5 L 7,7 L 5,7 Z M 5,9 L 7,9 L 7,11 L 5,11 Z M 5,13 L 7,13 L 7,15 L 5,15 Z M 13,5 L 15,5 L 15,7 L 13,7 Z M 13,9 L 15,9 L 15,11 L 13,11 Z M 13,13 L 15,13 L 15,15 L 13,15 Z</StreamGeometry>
+
+</ResourceDictionary>

--- a/src/Vido.Views/Controls/VideoPlayerControl.xaml
+++ b/src/Vido.Views/Controls/VideoPlayerControl.xaml
@@ -1,0 +1,233 @@
+<UserControl x:Class="Vido.Views.Controls.VideoPlayerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="{DynamicResource EditorBackgroundBrush}">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="PlayerStyles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <BooleanToVisibilityConverter x:Key="BoolToVis" />
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <!-- Video display area -->
+            <RowDefinition Height="*" />
+            <!-- Controls bar -->
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <!-- Empty state: no video loaded -->
+        <StackPanel x:Name="EmptyState"
+                    Grid.Row="0"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Visibility="Visible">
+            <Path Data="{StaticResource FilmReelGeometry}"
+                  Stroke="{DynamicResource DisabledForegroundBrush}"
+                  StrokeThickness="1.2"
+                  Fill="Transparent"
+                  Stretch="Uniform"
+                  Width="48" Height="48"
+                  HorizontalAlignment="Center"
+                  Margin="0,0,0,16" />
+            <TextBlock Text="Open a video file to begin"
+                       Foreground="{DynamicResource DisabledForegroundBrush}"
+                       FontSize="16"
+                       FontFamily="Segoe UI"
+                       HorizontalAlignment="Center" />
+        </StackPanel>
+
+        <!-- Video display surface -->
+        <Image x:Name="VideoSurface"
+               Grid.Row="0"
+               Stretch="Uniform"
+               RenderOptions.BitmapScalingMode="HighQuality"
+               Visibility="Collapsed" />
+
+        <!-- ═══ Transport controls bar ═══ -->
+        <Border Grid.Row="1"
+                Background="{DynamicResource EditorBackgroundBrush}"
+                BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                BorderThickness="0,1,0,0"
+                Padding="8,4">
+
+            <Grid>
+                <Grid.RowDefinitions>
+                    <!-- Seek bar row -->
+                    <RowDefinition Height="Auto" />
+                    <!-- Controls row -->
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <!-- Seek bar with time labels -->
+                <Grid Grid.Row="0" Margin="0,2,0,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding PositionText}"
+                               Style="{StaticResource TimeLabelStyle}"
+                               Margin="0,0,8,0" />
+
+                    <Slider x:Name="SeekSlider"
+                            Grid.Column="1"
+                            Style="{StaticResource SeekSliderStyle}"
+                            Value="{Binding SeekPosition, Mode=TwoWay}"
+                            IsEnabled="{Binding HasMedia}" />
+
+                    <TextBlock Grid.Column="2"
+                               Text="{Binding DurationText}"
+                               Style="{StaticResource TimeLabelStyle}"
+                               Margin="8,0,0,0" />
+                </Grid>
+
+                <!-- Transport buttons and volume -->
+                <Grid Grid.Row="1" Margin="0,2,0,2">
+                    <Grid.ColumnDefinitions>
+                        <!-- Left section: transport buttons -->
+                        <ColumnDefinition Width="Auto" />
+                        <!-- Center spacer -->
+                        <ColumnDefinition Width="*" />
+                        <!-- Right section: volume + loop -->
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Transport buttons -->
+                    <StackPanel Grid.Column="0"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center">
+                        <!-- Skip Previous -->
+                        <Button Style="{StaticResource TransportButtonStyle}"
+                                Command="{Binding SkipPreviousCommand}"
+                                IsEnabled="{Binding HasMedia}"
+                                ToolTip="Previous">
+                            <Path Data="{StaticResource SkipPreviousGeometry}"
+                                  Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                  Stretch="Uniform" Width="14" Height="14" />
+                        </Button>
+
+                        <!-- Play / Pause -->
+                        <Button Style="{StaticResource PlayPauseButtonStyle}"
+                                Command="{Binding PlayPauseCommand}"
+                                IsEnabled="{Binding HasMedia}"
+                                ToolTip="Play/Pause">
+                            <Grid>
+                                <Path x:Name="PlayIcon"
+                                      Data="{StaticResource PlayIconGeometry}"
+                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      Stretch="Uniform" Width="16" Height="16"
+                                      Visibility="{Binding ShowPlayIcon, Converter={StaticResource BoolToVis}}" />
+                                <Path x:Name="PauseIcon"
+                                      Data="{StaticResource PauseIconGeometry}"
+                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      Stretch="Uniform" Width="16" Height="16">
+                                    <Path.Style>
+                                        <Style TargetType="Path">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ShowPlayIcon}" Value="True">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Path.Style>
+                                </Path>
+                            </Grid>
+                        </Button>
+
+                        <!-- Stop -->
+                        <Button Style="{StaticResource TransportButtonStyle}"
+                                Command="{Binding StopCommand}"
+                                IsEnabled="{Binding HasMedia}"
+                                ToolTip="Stop">
+                            <Path Data="{StaticResource StopIconGeometry}"
+                                  Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                  Stretch="Uniform" Width="12" Height="12" />
+                        </Button>
+
+                        <!-- Skip Next -->
+                        <Button Style="{StaticResource TransportButtonStyle}"
+                                Command="{Binding SkipNextCommand}"
+                                IsEnabled="{Binding HasMedia}"
+                                ToolTip="Next">
+                            <Path Data="{StaticResource SkipNextGeometry}"
+                                  Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                  Stretch="Uniform" Width="14" Height="14" />
+                        </Button>
+                    </StackPanel>
+
+                    <!-- Volume and loop controls -->
+                    <StackPanel Grid.Column="2"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center">
+                        <!-- Loop toggle -->
+                        <ToggleButton Style="{StaticResource TransportToggleButtonStyle}"
+                                      IsChecked="{Binding IsLooping}"
+                                      ToolTip="Loop">
+                            <Path Data="{StaticResource LoopIconGeometry}"
+                                  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=ToggleButton}}"
+                                  StrokeThickness="1.2"
+                                  Fill="Transparent"
+                                  Stretch="Uniform" Width="14" Height="14" />
+                        </ToggleButton>
+
+                        <!-- Shuffle toggle -->
+                        <ToggleButton Style="{StaticResource TransportToggleButtonStyle}"
+                                      IsChecked="{Binding IsShuffling}"
+                                      ToolTip="Shuffle">
+                            <Path Data="{StaticResource ShuffleIconGeometry}"
+                                  Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=ToggleButton}}"
+                                  StrokeThickness="1.2"
+                                  Fill="Transparent"
+                                  Stretch="Uniform" Width="14" Height="14" />
+                        </ToggleButton>
+
+                        <!-- Mute toggle -->
+                        <Button Style="{StaticResource TransportButtonStyle}"
+                                Width="28" Height="28" Padding="5"
+                                Command="{Binding ToggleMuteCommand}"
+                                ToolTip="Mute">
+                            <Grid>
+                                <Path Data="{StaticResource VolumeHighGeometry}"
+                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      Stretch="Uniform" Width="14" Height="14">
+                                    <Path.Style>
+                                        <Style TargetType="Path">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsMuted}" Value="True">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Path.Style>
+                                </Path>
+                                <Path Data="{StaticResource VolumeMutedGeometry}"
+                                      Fill="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      Stroke="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                      StrokeThickness="1.5"
+                                      Stretch="Uniform" Width="14" Height="14"
+                                      Visibility="{Binding IsMuted, Converter={StaticResource BoolToVis}}" />
+                            </Grid>
+                        </Button>
+
+                        <!-- Volume slider -->
+                        <Slider x:Name="VolumeSlider"
+                                Style="{StaticResource VolumeSliderStyle}"
+                                Value="{Binding Volume, Mode=TwoWay}"
+                                ToolTip="Volume"
+                                Margin="4,0,0,0" />
+                    </StackPanel>
+                </Grid>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/Vido.Views/Controls/VideoPlayerControl.xaml.cs
+++ b/src/Vido.Views/Controls/VideoPlayerControl.xaml.cs
@@ -1,0 +1,213 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Vido.Core.Playback;
+using Vido.ViewModels;
+
+namespace Vido.Views.Controls;
+
+/// <summary>
+/// Displays decoded video frames in a WriteableBitmap and hosts transport controls.
+/// Subscribes to <see cref="VideoPlayerViewModel.FrameReady"/> to render frames.
+/// </summary>
+public partial class VideoPlayerControl : UserControl
+{
+    private WriteableBitmap? _bitmap;
+    private VideoPlayerViewModel? _viewModel;
+
+    public VideoPlayerControl()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+
+        // Seek slider: click to jump, hold-and-drag to scrub continuously.
+        // Must use AddHandler with handledEventsToo because Slider's IsMoveToPointEnabled
+        // marks PreviewMouseLeftButtonDown as Handled in its class handler.
+        SeekSlider.AddHandler(
+            PreviewMouseLeftButtonDownEvent,
+            new MouseButtonEventHandler(OnSeekSliderMouseDown),
+            handledEventsToo: true);
+        SeekSlider.AddHandler(
+            PreviewMouseLeftButtonUpEvent,
+            new MouseButtonEventHandler(OnSeekSliderMouseUp),
+            handledEventsToo: true);
+        SeekSlider.AddHandler(
+            PreviewMouseMoveEvent,
+            new MouseEventHandler(OnSeekSliderMouseMove),
+            handledEventsToo: true);
+
+        // Volume slider: click sets position, hold-and-drag adjusts continuously.
+        VolumeSlider.AddHandler(
+            PreviewMouseLeftButtonDownEvent,
+            new MouseButtonEventHandler(OnVolumeSliderMouseDown),
+            handledEventsToo: true);
+        VolumeSlider.AddHandler(
+            PreviewMouseLeftButtonUpEvent,
+            new MouseButtonEventHandler(OnVolumeSliderMouseUp),
+            handledEventsToo: true);
+        VolumeSlider.AddHandler(
+            PreviewMouseMoveEvent,
+            new MouseEventHandler(OnVolumeSliderMouseMove),
+            handledEventsToo: true);
+    }
+
+    private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.FrameReady -= OnFrameReady;
+            _viewModel.PropertyChanged -= OnVmPropertyChanged;
+        }
+
+        _viewModel = e.NewValue as VideoPlayerViewModel;
+
+        if (_viewModel is not null)
+        {
+            _viewModel.FrameReady += OnFrameReady;
+            _viewModel.PropertyChanged += OnVmPropertyChanged;
+            UpdateVisualState(_viewModel.HasMedia);
+        }
+    }
+
+    private void OnVmPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(VideoPlayerViewModel.HasMedia) && _viewModel is not null)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                var hasMedia = _viewModel.HasMedia;
+                UpdateVisualState(hasMedia);
+
+                // Clear the bitmap when media is unloaded (Stop)
+                if (!hasMedia)
+                {
+                    _bitmap = null;
+                    VideoSurface.Source = null;
+                }
+            });
+        }
+    }
+
+    private void UpdateVisualState(bool hasMedia)
+    {
+        EmptyState.Visibility = hasMedia ? Visibility.Collapsed : Visibility.Visible;
+        VideoSurface.Visibility = hasMedia ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    /// <summary>
+    /// Renders a decoded BGRA32 frame into the WriteableBitmap.
+    /// Called from the engine's decode thread — marshals to the UI thread.
+    /// </summary>
+    private void OnFrameReady(FrameData frame)
+    {
+        Dispatcher.BeginInvoke(() =>
+        {
+            // Recreate bitmap if dimensions changed
+            if (_bitmap is null || _bitmap.PixelWidth != frame.Width || _bitmap.PixelHeight != frame.Height)
+            {
+                _bitmap = new WriteableBitmap(frame.Width, frame.Height, 96, 96, PixelFormats.Bgra32, null);
+                VideoSurface.Source = _bitmap;
+            }
+
+            _bitmap.Lock();
+            try
+            {
+                _bitmap.WritePixels(
+                    new Int32Rect(0, 0, frame.Width, frame.Height),
+                    frame.PixelData,
+                    frame.Stride,
+                    0);
+            }
+            finally
+            {
+                _bitmap.Unlock();
+            }
+        });
+    }
+
+    // ── Seek slider events ──
+
+    private bool _isSeekDragging;
+
+    /// <summary>
+    /// On mouse-down: suppress engine position updates, seek to the clicked position,
+    /// and capture the mouse so we receive move events for drag-to-scrub.
+    /// </summary>
+    private void OnSeekSliderMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (_viewModel is null || !_viewModel.HasMedia) return;
+
+        _isSeekDragging = true;
+        _viewModel.BeginSeek();
+        SeekSlider.CaptureMouse();
+
+        // IsMoveToPointEnabled already moved the slider value on this click.
+        _viewModel.ApplySeek();
+
+        // Prevent the slider's built-in thumb drag machinery.
+        e.Handled = true;
+    }
+
+    /// <summary>
+    /// While dragging, compute seek position from mouse X and seek continuously.
+    /// </summary>
+    private void OnSeekSliderMouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isSeekDragging || _viewModel is null) return;
+
+        var pos = e.GetPosition(SeekSlider);
+        var ratio = Math.Clamp(pos.X / SeekSlider.ActualWidth, 0, 1);
+        SeekSlider.Value = SeekSlider.Minimum + ratio * (SeekSlider.Maximum - SeekSlider.Minimum);
+        _viewModel.ApplySeek();
+    }
+
+    /// <summary>
+    /// On mouse-up: release capture and resume engine position updates.
+    /// </summary>
+    private void OnSeekSliderMouseUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_isSeekDragging) return;
+        _isSeekDragging = false;
+        SeekSlider.ReleaseMouseCapture();
+        _viewModel?.EndSeek();
+    }
+
+    // ── Volume slider events ──
+
+    private bool _isVolumeDragging;
+
+    /// <summary>
+    /// Capture the mouse on the slider so we receive MouseMove while held.
+    /// IsMoveToPointEnabled already set the value on this click.
+    /// </summary>
+    private void OnVolumeSliderMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        _isVolumeDragging = true;
+        VolumeSlider.CaptureMouse();
+        e.Handled = true; // Prevent thumb's internal drag machinery
+    }
+
+    /// <summary>
+    /// While dragging, compute volume from mouse X position relative to the slider.
+    /// </summary>
+    private void OnVolumeSliderMouseMove(object sender, MouseEventArgs e)
+    {
+        if (!_isVolumeDragging) return;
+
+        var pos = e.GetPosition(VolumeSlider);
+        var ratio = Math.Clamp(pos.X / VolumeSlider.ActualWidth, 0, 1);
+        VolumeSlider.Value = VolumeSlider.Minimum + ratio * (VolumeSlider.Maximum - VolumeSlider.Minimum);
+    }
+
+    /// <summary>
+    /// Release capture and stop drag tracking.
+    /// </summary>
+    private void OnVolumeSliderMouseUp(object sender, MouseButtonEventArgs e)
+    {
+        if (!_isVolumeDragging) return;
+        _isVolumeDragging = false;
+        VolumeSlider.ReleaseMouseCapture();
+    }
+}

--- a/src/Vido.Views/MainWindow.xaml
+++ b/src/Vido.Views/MainWindow.xaml
@@ -73,12 +73,59 @@
                 <!-- Editor Area -->
                 <Grid Grid.Column="3"
                       Background="{DynamicResource EditorBackgroundBrush}">
-                    <TextBlock Text="Open a video file to begin"
-                               Foreground="{DynamicResource DisabledForegroundBrush}"
-                               FontSize="16"
-                               FontFamily="Segoe UI"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center" />
+                    <Grid.RowDefinitions>
+                        <!-- Tab strip -->
+                        <RowDefinition Height="Auto" />
+                        <!-- Tab content -->
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <!-- Tab strip -->
+                    <Border Grid.Row="0"
+                            Background="{DynamicResource TabInactiveBackgroundBrush}"
+                            BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                            BorderThickness="0,0,0,1">
+                        <StackPanel Orientation="Horizontal">
+                            <!-- Player tab — always leftmost, no close button -->
+                            <Border x:Name="PlayerTab"
+                                    Height="35"
+                                    Padding="12,0"
+                                    Background="{DynamicResource EditorBackgroundBrush}"
+                                    Cursor="Hand"
+                                    MouseLeftButtonDown="OnPlayerTabClick">
+                                <StackPanel Orientation="Horizontal"
+                                            VerticalAlignment="Center">
+                                    <Path Data="M 4,2 L 4,18 L 18,10 Z"
+                                          Fill="{DynamicResource SecondaryForegroundBrush}"
+                                          Stretch="Uniform"
+                                          Width="10" Height="10"
+                                          Margin="0,0,6,0"
+                                          VerticalAlignment="Center" />
+                                    <TextBlock Text="Player"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                               FontFamily="Segoe UI"
+                                               FontSize="13"
+                                               VerticalAlignment="Center" />
+                                </StackPanel>
+                                <!-- Active tab bottom accent line -->
+                                <Border.Effect>
+                                    <DropShadowEffect ShadowDepth="0" BlurRadius="0" />
+                                </Border.Effect>
+                            </Border>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Active tab bottom border (accent line under active tab) -->
+                    <Border Grid.Row="0"
+                            VerticalAlignment="Bottom"
+                            Height="1"
+                            Width="{Binding ActualWidth, ElementName=PlayerTab}"
+                            HorizontalAlignment="Left"
+                            Background="{DynamicResource AccentBrush}" />
+
+                    <!-- Tab content area -->
+                    <controls:VideoPlayerControl x:Name="VideoPlayer"
+                                                 Grid.Row="1" />
                 </Grid>
             </Grid>
 

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1,9 +1,11 @@
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Shell;
 using Vido.Core.Layout;
+using Vido.Core.Playback;
 using Vido.Core.Settings;
 using Vido.Core.State;
 using Vido.Core.Windowing;
@@ -25,6 +27,7 @@ public partial class MainWindow : Window
     private readonly IStateService _stateService;
     private readonly ISettingsService _settingsService;
     private readonly FileExplorerViewModel _fileExplorerViewModel;
+    private readonly VideoPlayerViewModel _videoPlayerViewModel;
 
     private TitleBarViewModel? _titleBarViewModel;
     private ActivityBarViewModel? _activityBarViewModel;
@@ -34,16 +37,19 @@ public partial class MainWindow : Window
     public MainWindow(
         IStateService stateService,
         ISettingsService settingsService,
-        FileExplorerViewModel fileExplorerViewModel)
+        FileExplorerViewModel fileExplorerViewModel,
+        VideoPlayerViewModel videoPlayerViewModel)
     {
         _stateService = stateService;
         _settingsService = settingsService;
         _fileExplorerViewModel = fileExplorerViewModel;
+        _videoPlayerViewModel = videoPlayerViewModel;
 
         InitializeComponent();
         SetupWindowChrome();
         SetupTitleBar();
         SetupLayout();
+        SetupVideoPlayer();
         SetupFileExplorer();
         RestoreWindowState();
     }
@@ -98,6 +104,11 @@ public partial class MainWindow : Window
         ActivityBar.UpdateActiveStates();
     }
 
+    private void SetupVideoPlayer()
+    {
+        VideoPlayer.DataContext = _videoPlayerViewModel;
+    }
+
     private void SetupFileExplorer()
     {
         _fileExplorerPanel = new FileExplorerPanel
@@ -113,6 +124,12 @@ public partial class MainWindow : Window
         // Wire the "Open Folder" button inside the explorer panel
         _fileExplorerPanel.OpenFolderRequested += ShowOpenFolderDialog;
 
+        // Wire play file from context menu
+        _fileExplorerPanel.PlayFileRequested += OnPlayFileRequested;
+
+        // Wire double-click on video file to play
+        _fileExplorerPanel.VideoFileDoubleClicked += OnPlayFileRequested;
+
         // Subscribe to VM changes to update Close Folder menu state
         _fileExplorerViewModel.PropertyChanged += (_, e) =>
         {
@@ -126,6 +143,10 @@ public partial class MainWindow : Window
         // Restore last opened folder from state
         _fileExplorerViewModel.RestoreLastFolder();
         TitleBar.SetCloseFolderEnabled(_fileExplorerViewModel.HasFolderOpen);
+
+        // Sync explorer root to video player for skip prev/next across all folders
+        if (_fileExplorerViewModel.FolderPath is not null)
+            _videoPlayerViewModel.SetExplorerRoot(_fileExplorerViewModel.FolderPath);
     }
 
     private void ShowOpenFolderDialog()
@@ -144,6 +165,7 @@ public partial class MainWindow : Window
     private void OnFolderOpened(string path)
     {
         _fileExplorerViewModel.OpenFolder(path);
+        _videoPlayerViewModel.SetExplorerRoot(path);
 
         // Ensure sidebar is visible and Explorer panel is active
         if (_activityBarViewModel is not null)
@@ -157,11 +179,31 @@ public partial class MainWindow : Window
     private void OnFolderClosed()
     {
         _fileExplorerViewModel.CloseFolder();
+        _videoPlayerViewModel.SetExplorerRoot(null);
     }
 
     private void OnFolderRescanned()
     {
         _fileExplorerViewModel.RescanFolder();
+    }
+
+    private async void OnPlayFileRequested(Core.FileSystem.FileNode node)
+    {
+        if (!node.IsVideoFile || node.IsHidden) return;
+
+        try
+        {
+            await _videoPlayerViewModel.LoadAndPlayAsync(node.FullPath);
+        }
+        catch
+        {
+            // Playback errors are handled gracefully — video just won't play
+        }
+    }
+
+    private void OnPlayerTabClick(object sender, MouseButtonEventArgs e)
+    {
+        // Player tab is always active — no-op for now; future tabs will switch here.
     }
 
     private void OnPanelChanged(object sender, RoutedEventArgs e)

--- a/src/Vido.Views/Panels/FileExplorerPanel.xaml
+++ b/src/Vido.Views/Panels/FileExplorerPanel.xaml
@@ -146,6 +146,7 @@
                     <Style TargetType="TreeViewItem"
                            BasedOn="{StaticResource FileExplorerTreeViewItemStyle}">
                         <EventSetter Event="PreviewMouseRightButtonUp" Handler="OnTreeItemPreviewRightClick" />
+                        <EventSetter Event="MouseDoubleClick" Handler="OnTreeItemDoubleClick" />
                     </Style>
                 </TreeView.ItemContainerStyle>
                 <TreeView.ItemTemplate>

--- a/src/Vido.Views/Panels/FileExplorerPanel.xaml.cs
+++ b/src/Vido.Views/Panels/FileExplorerPanel.xaml.cs
@@ -25,6 +25,11 @@ public partial class FileExplorerPanel : UserControl
     /// </summary>
     public event Action<FileNode>? PlayFileRequested;
 
+    /// <summary>
+    /// Raised when the user double-clicks a video file in the tree.
+    /// </summary>
+    public event Action<FileNode>? VideoFileDoubleClicked;
+
     public FileExplorerPanel()
     {
         InitializeComponent();
@@ -118,6 +123,27 @@ public partial class FileExplorerPanel : UserControl
 
         menu.Tag = node;
         item.ContextMenu = menu;
+    }
+
+    /// <summary>
+    /// Handles double-click on a TreeViewItem. If the item is a non-hidden video file,
+    /// raises <see cref="VideoFileDoubleClicked"/> to trigger playback.
+    /// </summary>
+    private void OnTreeItemDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not TreeViewItem item || item.DataContext is not FileNode node)
+            return;
+
+        // Only handle for the directly-clicked item
+        var nearestItem = FindVisualParent<TreeViewItem>(e.OriginalSource as DependencyObject);
+        if (nearestItem != item)
+            return;
+
+        if (node.IsVideoFile && !node.IsHidden)
+        {
+            VideoFileDoubleClicked?.Invoke(node);
+            e.Handled = true;
+        }
     }
 
     // ─── Context menu click handlers ────────────────────────────────

--- a/tests/Vido.Tests/VideoPlayerViewModelTests.cs
+++ b/tests/Vido.Tests/VideoPlayerViewModelTests.cs
@@ -1,0 +1,617 @@
+using NSubstitute;
+using Vido.Core.Playback;
+using Vido.ViewModels;
+using Xunit;
+
+namespace Vido.Tests;
+
+/// <summary>
+/// Tests for VideoPlayerViewModel.
+/// Uses a mock IVideoEngine to verify ViewModel behavior without FFmpeg DLLs.
+/// </summary>
+public class VideoPlayerViewModelTests : IDisposable
+{
+    private readonly IVideoEngine _engine;
+    private readonly VideoPlayerViewModel _sut;
+
+    public VideoPlayerViewModelTests()
+    {
+        _engine = Substitute.For<IVideoEngine>();
+        _engine.Volume.Returns(75);
+        _engine.IsMuted.Returns(false);
+        _engine.IsLooping.Returns(false);
+        _sut = new VideoPlayerViewModel(_engine);
+    }
+
+    // ── Initial State ──
+
+    [Fact]
+    public void InitialState_IsNone()
+    {
+        Assert.Equal(PlaybackState.None, _sut.State);
+    }
+
+    [Fact]
+    public void InitialPosition_IsZero()
+    {
+        Assert.Equal(TimeSpan.Zero, _sut.Position);
+    }
+
+    [Fact]
+    public void InitialDuration_IsZero()
+    {
+        Assert.Equal(TimeSpan.Zero, _sut.Duration);
+    }
+
+    [Fact]
+    public void InitialVolume_InheritsFromEngine()
+    {
+        Assert.Equal(75, _sut.Volume);
+    }
+
+    [Fact]
+    public void InitialIsMuted_InheritsFromEngine()
+    {
+        Assert.False(_sut.IsMuted);
+    }
+
+    [Fact]
+    public void InitialIsLooping_InheritsFromEngine()
+    {
+        Assert.False(_sut.IsLooping);
+    }
+
+    [Fact]
+    public void InitialHasMedia_IsFalse()
+    {
+        Assert.False(_sut.HasMedia);
+    }
+
+    [Fact]
+    public void InitialShowPlayIcon_IsTrue()
+    {
+        Assert.True(_sut.ShowPlayIcon);
+    }
+
+    [Fact]
+    public void InitialPositionText_IsZero()
+    {
+        Assert.Equal("00:00", _sut.PositionText);
+    }
+
+    [Fact]
+    public void InitialDurationText_IsZero()
+    {
+        Assert.Equal("00:00", _sut.DurationText);
+    }
+
+    [Fact]
+    public void InitialCurrentFilePath_IsNull()
+    {
+        Assert.Null(_sut.CurrentFilePath);
+    }
+
+    [Fact]
+    public void InitialCurrentMetadata_IsNull()
+    {
+        Assert.Null(_sut.CurrentMetadata);
+    }
+
+    // ── Volume ──
+
+    [Fact]
+    public void SetVolume_ForwardsToEngine()
+    {
+        _sut.Volume = 50;
+        _engine.Volume = 50;
+    }
+
+    [Theory]
+    [InlineData(-10, 0)]
+    [InlineData(0, 0)]
+    [InlineData(50, 50)]
+    [InlineData(100, 100)]
+    [InlineData(150, 100)]
+    public void SetVolume_ClampsValue(int input, int expected)
+    {
+        _sut.Volume = input;
+        _engine.Received().Volume = expected;
+    }
+
+    // ── Mute / Loop toggles ──
+
+    [Fact]
+    public void ToggleMute_SetsIsMutedTrue()
+    {
+        _sut.ToggleMute();
+        Assert.True(_sut.IsMuted);
+    }
+
+    [Fact]
+    public void ToggleMute_ForwardsToEngine()
+    {
+        _sut.ToggleMute();
+        _engine.Received().IsMuted = true;
+    }
+
+    [Fact]
+    public void ToggleLoop_SetsIsLoopingTrue()
+    {
+        _sut.ToggleLoop();
+        Assert.True(_sut.IsLooping);
+    }
+
+    [Fact]
+    public void ToggleLoop_ForwardsToEngine()
+    {
+        _sut.ToggleLoop();
+        _engine.Received().IsLooping = true;
+    }
+
+    // ── PlayPause / Stop without media ──
+
+    [Fact]
+    public void PlayPause_DoesNothing_WhenNoMedia()
+    {
+        _sut.PlayPause();
+        _engine.DidNotReceive().Play();
+        _engine.DidNotReceive().Pause();
+    }
+
+    [Fact]
+    public void Stop_DoesNothing_WhenNoMedia()
+    {
+        _sut.Stop();
+        _engine.DidNotReceive().Stop();
+    }
+
+    // ── Engine event handling ──
+
+    [Fact]
+    public void StateChanged_UpdatesViewModelState()
+    {
+        _engine.StateChanged += Raise.Event<Action<PlaybackState>>(PlaybackState.Playing);
+
+        Assert.Equal(PlaybackState.Playing, _sut.State);
+        Assert.False(_sut.ShowPlayIcon);
+    }
+
+    [Fact]
+    public void StateChanged_ToPaused_ShowsPlayIcon()
+    {
+        _engine.StateChanged += Raise.Event<Action<PlaybackState>>(PlaybackState.Paused);
+
+        Assert.Equal(PlaybackState.Paused, _sut.State);
+        Assert.True(_sut.ShowPlayIcon);
+    }
+
+    [Fact]
+    public void PositionChanged_UpdatesPositionAndText()
+    {
+        var pos = TimeSpan.FromMinutes(2) + TimeSpan.FromSeconds(30);
+        _engine.PositionChanged += Raise.Event<Action<TimeSpan>>(pos);
+
+        Assert.Equal(pos, _sut.Position);
+        Assert.Equal("02:30", _sut.PositionText);
+    }
+
+    [Fact]
+    public void FrameReady_RaisesViewModelEvent()
+    {
+        FrameData? received = null;
+        _sut.FrameReady += f => received = f;
+
+        var frame = new FrameData
+        {
+            PixelData = new byte[100],
+            Width = 10,
+            Height = 10,
+            Stride = 40
+        };
+
+        _engine.FrameReady += Raise.Event<Action<FrameData>>(frame);
+
+        Assert.Same(frame, received);
+    }
+
+    // ── FormatTime ──
+
+    [Theory]
+    [InlineData(0, "00:00")]
+    [InlineData(65, "01:05")]
+    [InlineData(3599, "59:59")]
+    [InlineData(3600, "1:00:00")]
+    [InlineData(7261, "2:01:01")]
+    public void FormatTime_FormatsCorrectly(int totalSeconds, string expected)
+    {
+        var result = VideoPlayerViewModel.FormatTime(TimeSpan.FromSeconds(totalSeconds));
+        Assert.Equal(expected, result);
+    }
+
+    // ── GetAdjacentVideoFile ──
+
+    [Fact]
+    public void GetAdjacentVideoFile_ReturnsNull_WhenNoCurrentFile()
+    {
+        var result = _sut.GetAdjacentVideoFile(1);
+        Assert.Null(result);
+    }
+
+    // ── Skip wrapping with temp files ──
+
+    [Fact]
+    public async Task SkipNext_WrapsToFirstFile_WhenAtEnd()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            // Load the last file
+            await _sut.LoadAndPlayAsync(files[2]);
+
+            // GetAdjacentVideoFile should wrap to first
+            var next = _sut.GetAdjacentVideoFile(1);
+            Assert.Equal(files[0], next);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task SkipPrevious_WrapsToLastFile_WhenAtBeginning()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            // Load the first file
+            await _sut.LoadAndPlayAsync(files[0]);
+
+            // GetAdjacentVideoFile(-1) should wrap to last
+            var prev = _sut.GetAdjacentVideoFile(-1);
+            Assert.Equal(files[2], prev);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task GetAdjacentVideoFile_ReturnsMiddleFile_Normal()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+
+            var next = _sut.GetAdjacentVideoFile(1);
+            Assert.Equal(files[1], next);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── Shuffle ──
+
+    [Fact]
+    public void InitialIsShuffling_IsFalse()
+    {
+        Assert.False(_sut.IsShuffling);
+    }
+
+    [Fact]
+    public void ToggleShuffle_SetsIsShufflingTrue()
+    {
+        _sut.ToggleShuffle();
+        Assert.True(_sut.IsShuffling);
+    }
+
+    [Fact]
+    public void ToggleShuffle_Twice_SetsIsShufflingFalse()
+    {
+        _sut.ToggleShuffle();
+        _sut.ToggleShuffle();
+        Assert.False(_sut.IsShuffling);
+    }
+
+    [Fact]
+    public async Task BuildShufflePlaylist_ContainsAllSiblings()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+            _sut.ToggleShuffle(); // builds the shuffle playlist
+
+            // BuildShufflePlaylist is internal, but we can verify via GetShuffleFile
+            // The playlist should contain all 3 files, no duplicates
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            // Walk through the shuffle playlist using GetShuffleFile
+            for (int i = 0; i < files.Length; i++)
+            {
+                var f = _sut.GetShuffleFile(i);
+                Assert.NotNull(f);
+                Assert.True(visited.Add(f!), $"Duplicate in shuffle playlist: {f}");
+            }
+            Assert.Equal(files.Length, visited.Count);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task BuildShufflePlaylist_CurrentFileIsFirst()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[1]); // load middle file
+            _sut.ToggleShuffle();
+
+            var first = _sut.GetShuffleFile(0);
+            Assert.Equal(files[1], first);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task GetShuffleFile_WrapsAround()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+            _sut.ToggleShuffle();
+
+            // Going past the end should wrap around
+            var wrapped = _sut.GetShuffleFile(3);
+            var first = _sut.GetShuffleFile(0);
+            Assert.Equal(first, wrapped);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task GetShuffleFile_WrapsBackward()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+            _sut.ToggleShuffle();
+
+            // Going before the beginning should wrap to end
+            var wrapBack = _sut.GetShuffleFile(-1);
+            var last = _sut.GetShuffleFile(2);
+            Assert.Equal(last, wrapBack);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task ClearShufflePlaylist_OnToggleOff()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+            _sut.ToggleShuffle(); // on
+            _sut.ToggleShuffle(); // off — clears the list
+
+            var result = _sut.GetShuffleFile(0);
+            Assert.Null(result);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task GetNextFile_UsesShuffle_WhenShuffling()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+            _sut.ToggleShuffle();
+
+            var next = _sut.GetNextFile();
+            Assert.NotNull(next);
+            // In shuffle mode, next should be the file at shuffle index 1
+            var expectedShuffle = _sut.GetShuffleFile(1);
+            Assert.Equal(expectedShuffle, next);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public async Task GetNextFile_UsesAlphabetical_WhenNotShuffling()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            await _sut.LoadAndPlayAsync(files[0]);
+
+            var next = _sut.GetNextFile();
+            Assert.Equal(files[1], next);
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── ApplySeek ──
+
+    [Fact]
+    public void ApplySeek_SeeksEngine_WhenHasDuration()
+    {
+        // Simulate having media loaded with a known duration
+        _engine.Duration.Returns(TimeSpan.FromSeconds(100));
+        _engine.StateChanged += Raise.Event<Action<PlaybackState>>(PlaybackState.Playing);
+
+        // Set up state as if media was loaded
+        _sut.GetType().GetProperty("Duration")!.SetValue(_sut, TimeSpan.FromSeconds(100));
+        _sut.GetType().GetProperty("HasMedia")!.SetValue(_sut, true);
+
+        // Simulate click at 50% position
+        _sut.GetType().GetProperty("SeekPosition")!.SetValue(_sut, 500.0);
+        _sut.ApplySeek();
+
+        _engine.Received().Seek(Arg.Is<TimeSpan>(t => Math.Abs(t.TotalSeconds - 50) < 0.1));
+    }
+
+    // ── Seek ──
+
+    [Fact]
+    public void BeginSeek_SuppressesPositionUpdates()
+    {
+        _sut.BeginSeek();
+
+        var pos = TimeSpan.FromSeconds(10);
+        _engine.PositionChanged += Raise.Event<Action<TimeSpan>>(pos);
+
+        // Position should not update during seeking
+        Assert.Equal(TimeSpan.Zero, _sut.Position);
+    }
+
+    [Fact]
+    public void EndSeek_ResumesPositionUpdates()
+    {
+        _sut.BeginSeek();
+        _sut.EndSeek();
+
+        var pos = TimeSpan.FromSeconds(10);
+        _engine.PositionChanged += Raise.Event<Action<TimeSpan>>(pos);
+
+        Assert.Equal(pos, _sut.Position);
+    }
+
+    // ── Helpers ──
+
+    /// <summary>Creates a temp directory with empty video stub files.</summary>
+    private static string CreateTempVideoDir(params string[] fileNames)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "vido_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(dir);
+        foreach (var name in fileNames)
+            File.WriteAllBytes(Path.Combine(dir, name), []);
+        return dir;
+    }
+
+    /// <summary>Creates a temp directory with nested subfolders and empty video stub files.</summary>
+    private static string CreateTempNestedVideoDir(params string[] relativePaths)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "vido_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(root);
+        foreach (var rel in relativePaths)
+        {
+            var full = Path.Combine(root, rel);
+            Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+            File.WriteAllBytes(full, []);
+        }
+        return root;
+    }
+
+    // ── SetExplorerRoot + nested folder scanning ──
+
+    [Fact]
+    public async Task SetExplorerRoot_ScansNestedFolders()
+    {
+        var root = CreateTempNestedVideoDir(
+            "a.mp4",
+            Path.Combine("sub1", "b.mp4"),
+            Path.Combine("sub2", "c.mp4"));
+        try
+        {
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            _sut.SetExplorerRoot(root);
+            await _sut.LoadAndPlayAsync(Path.Combine(root, "a.mp4"));
+
+            // Should find all 3 files across nested folders
+            var next = _sut.GetAdjacentVideoFile(1);
+            Assert.NotNull(next);
+
+            // Collect all reachable files via wrapping
+            var files = new List<string>();
+            var current = Path.Combine(root, "a.mp4");
+            for (int i = 0; i < 3; i++)
+            {
+                files.Add(_sut.GetAdjacentVideoFile(i)!);
+            }
+            Assert.Equal(3, files.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public async Task SkipNext_CrossesFolderBoundary()
+    {
+        var root = CreateTempNestedVideoDir(
+            "a.mp4",
+            Path.Combine("sub", "b.mp4"));
+        try
+        {
+            _engine.Duration.Returns(TimeSpan.FromMinutes(5));
+
+            _sut.SetExplorerRoot(root);
+            await _sut.LoadAndPlayAsync(Path.Combine(root, "a.mp4"));
+
+            var next = _sut.GetAdjacentVideoFile(1);
+            Assert.NotNull(next);
+            Assert.Contains("sub", next!);
+        }
+        finally { Directory.Delete(root, true); }
+    }
+
+    [Fact]
+    public void SetExplorerRoot_Null_ClearsList()
+    {
+        _sut.SetExplorerRoot(null);
+        var result = _sut.GetAdjacentVideoFile(1);
+        Assert.Null(result);
+    }
+
+    // ── Dispose ──
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        _sut.Dispose();
+        _sut.Dispose(); // should not throw
+    }
+
+    [Fact]
+    public void Dispose_UnsubscribesFromEngineEvents()
+    {
+        _sut.Dispose();
+
+        // After dispose, engine events should not update ViewModel state
+        _engine.StateChanged += Raise.Event<Action<PlaybackState>>(PlaybackState.Playing);
+        Assert.Equal(PlaybackState.None, _sut.State);
+    }
+
+    public void Dispose()
+    {
+        _sut.Dispose();
+    }
+}


### PR DESCRIPTION
- Implement VideoPlayerControl.xaml and VideoPlayerControl.xaml.cs for video playback UI.
- Create VideoPlayerViewModel to manage video playback logic and state.
- Add unit tests for VideoPlayerViewModel to ensure correct behavior and state management.
- Include functionality for seeking, volume control, mute, loop, and shuffle features.
- Ensure proper event handling for video frame rendering and playback state changes.