### PR TITLE
feat: Implement state persistence for user settings and recent files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### vi-016
+- Implemented full state persistence — Vido now remembers all settings and state between sessions
+- Added QueueSave() method to IStateService interface with 500ms debounce, matching SettingsService pattern
+- StateService implements IDisposable, has thread-safe debounce with lock guard on CancellationTokenSource
+- SettingsService debounce also hardened with lock guard for thread safety
+- Added RecentFiles list to AppState (capped at 10) with AddRecentFile() method (deduplicates case-insensitive, inserts at front)
+- VideoPlayerViewModel now injects ISettingsService + IStateService: restores volume/mute/loop from settings; saves volume/mute/loop on change; tracks last video path/position in state; saves position every 5 seconds of playback; adds to recent files on video load
+- Added RestoreLastVideoAsync() — reloads last played video paused at saved position on startup
+- MainWindowViewModel now injects ISettingsService: restores bottom/right panel visibility and status bar from settings; saves on toggle
+- ActivityBarViewModel now injects ISettingsService: restores sidebar visibility from settings; saves on change; added SetActivePanel() for non-toggling state restoration
+- FileExplorerViewModel now injects ISettingsService: restores ShowHiddenFiles from settings; saves on toggle
+- FileExplorerViewModel now calls QueueSave() after folder open/close, hide/unhide file mutations
+- MainWindow.xaml.cs RestoreLayoutState() restores panel dimensions, sidebar width, active sidebar panel, and last video on startup
+- MainWindow.xaml.cs SaveWindowState() now also persists sidebar width, panel heights, and sidebar visibility to settings
+- Sidebar width uses persisted value from settings instead of hardcoded 300px
+- Constructor property initialization uses backing fields to avoid wasteful save triggers during startup
+- Tests: 13 new (AppState.AddRecentFile, panel/sidebar/status bar persistence, settings/state round-trips) — 434 total, all passing
+
+#### vi-016 Bug Fixes
+- Fixed gray background on video restore: RestoreLastVideoAsync now uses Play→Seek→await SeekCompleted→Pause to ensure a frame renders before pausing (FFmpegVideoEngine's decode thread must be running for Seek to take effect)
+- Fixed bottom/right panel collapsed state not persisting: added BottomPanelCollapsed and RightPanelCollapsed to AppSettings, saved on change, restored on startup
+- Fixed sidebar panel reverting to Explorer on restart: RestoreLayoutState now calls OnPanelChanged after SetActivePanel to refresh sidebar content
+- Fixed recent files not shown in UI: File > Recent Files submenu now dynamically populates from AppState on open, clicking a recent file loads and plays it
+- Added "Show Hidden Files" toggle to View menu with checkmark state, synced with existing context menu checkmark in file explorer
+
+#### vi-016 Enhancements
+- View menu "Toggle Sidebar" and "Toggle Status Bar" now dynamically show "Show/Hide" text like Right/Bottom Panel menus
+- Added Playback Speed button to transport controls (visible in both normal and fullscreen modes) with 0.25x–4x presets, persisted in settings
+- Playback Speed submenu in Playback menu now functional with speed presets and active checkmark
+- IVideoEngine.SpeedRatio property added; FFmpegVideoEngine multiplies playback clock by speed ratio with smooth clock offset transitions on speed change
+- Added keyboard shortcuts: Ctrl+K (Close Folder), Ctrl+Shift+R (Rescan Folder)
+- Removed Zoom In/Out placeholder menu items (Ctrl+=, Ctrl+-)
+- Added "Clear Watch History" button at the bottom of File > Recent Files submenu with separator
+
+#### vi-016 Code Audit
+- Fixed fullscreen transitions incorrectly saving transient panel state: added SuppressSettingsSave guard on MainWindowViewModel, used during Enter/ExitFullscreen to prevent reactive save handlers from persisting hidden-panel state
+- Fixed _lastSavedPositionSeconds not reset when loading new video: position save debounce now starts fresh per video
+- Removed dead ConfirmOnExit property from AppSettings (never read or exposed in UI)
+- Removed redundant SidebarVisible save in SaveWindowState() (already handled reactively by ActivityBarViewModel)
+- Made SettingsService testable with custom directory constructor (test isolation)
+
 ### vi-015
 - Implemented fullscreen mode toggle via F11, F key, or double-click on video area
 - EnterFullscreen saves all pre-fullscreen state (window geometry, sidebar, bottom/right panel, status bar visibility) and hides all UI chrome (title bar, activity bar, sidebar, tab strip, status bar, bottom panel, right panel)

--- a/Context/IMPLEMENTATION_PLAN.md
+++ b/Context/IMPLEMENTATION_PLAN.md
@@ -1369,6 +1369,7 @@ For a developer to create a Vido plugin:
 12. Wire plugin-contributed file handlers into file double-click dispatch
 13. Wire plugin-contributed file icons into the explorer's icon resolution
 14. Write extensive unit tests for PluginLoader, PluginContext, and contribution registry
+15. Ensure plugins are easy to test - allow users to add custom repositories, the default should always be active - and lets set this up as part of the task and test it, but they should be able to add any number of custome repositories for getting plugins so they dont depend on the main repo owner adding their plugins. It should should also have the capability to specify a local repository on their machine for easy testing. 
 
 **Acceptance Criteria**:
 - If a plugin directory exists with valid `plugin.json` and DLL, it is loaded and activated on startup

--- a/Context/TEST_PLANS/vi-016_test_plan.md
+++ b/Context/TEST_PLANS/vi-016_test_plan.md
@@ -1,0 +1,72 @@
+# vi-016 State Persistence — Test Plan
+
+## Automated Tests (13 new, 434 total)
+
+### StatePersistenceTests — AppState.AddRecentFile (4)
+- [x] AddRecentFile_AddsToFront
+- [x] AddRecentFile_MovesDuplicateToFront
+- [x] AddRecentFile_TrimsToMax
+- [x] AddRecentFile_CaseInsensitiveDedupe
+
+### StatePersistenceTests — MainWindowViewModel Persistence (4)
+- [x] MainWindowVM_ToggleBottomPanel_SavesSettings
+- [x] MainWindowVM_ToggleRightPanel_SavesSettings
+- [x] MainWindowVM_ToggleStatusBar_SavesSettings
+- [x] MainWindowVM_RestoresPanelState_FromSettings
+
+### StatePersistenceTests — ActivityBarViewModel Persistence (3)
+- [x] ActivityBarVM_RestoresSidebarVisibility
+- [x] ActivityBarVM_SidebarToggle_SavesSettings
+- [x] ActivityBarVM_SetActivePanel_DoesNotToggleVisibility
+
+### StatePersistenceTests — Round-Trip Serialization (2)
+- [x] StateService_SaveAndLoad_RoundTripsRecentFiles
+- [x] SettingsService_SaveAndLoad_RoundTrips
+
+## Manual Verification
+
+### Window Geometry Persistence
+- [ ] Close and reopen — window position (X, Y) restored
+- [ ] Close and reopen — window size (W, H) restored
+- [ ] Close maximized — reopens maximized (restore bounds preserved)
+- [ ] Close in fullscreen — reopens at pre-fullscreen geometry
+
+### Video Playback Settings
+- [ ] Change volume → close → reopen → volume is restored
+- [ ] Mute → close → reopen → muted state is restored
+- [ ] Enable loop → close → reopen → loop is enabled
+- [ ] Volume slider at 42% → settings.json shows `"volume": 0.42`
+
+### Video State
+- [ ] Play video → close → reopen → video is loaded (paused) at last position
+- [ ] Play video to 2:30 → close → reopen → shows 2:30 in position text
+- [ ] Delete last played video → reopen → no error (graceful skip)
+- [ ] Recent files list shows last 10 opened videos in state.json
+
+### Sidebar Persistence
+- [ ] Hide sidebar → close → reopen → sidebar is hidden
+- [ ] Show sidebar → close → reopen → sidebar is visible
+- [ ] Resize sidebar to 400px → close → reopen → sidebar is 400px
+
+### Panel Persistence
+- [ ] Hide bottom panel → close → reopen → bottom panel hidden
+- [ ] Show right panel → close → reopen → right panel visible
+- [ ] Hide status bar → close → reopen → status bar hidden
+- [ ] Resize bottom panel to 150px → close → reopen → 150px height
+
+### File Explorer State
+- [ ] Open folder → close → reopen → folder is restored
+- [ ] Close folder → close app → reopen → no folder open
+- [ ] Hide file → close → reopen → file still hidden
+- [ ] Toggle ShowHiddenFiles → close → reopen → setting restored
+
+### Debounce Behavior
+- [ ] Rapidly change volume 10 times → only 1 disk write occurs (check file timestamps)
+- [ ] No save occurs during 500ms after last change
+- [ ] Save completes within ~600ms of last change
+
+### Edge Cases
+- [ ] First launch with no state.json/settings.json — uses defaults
+- [ ] Corrupted state.json — reverts to defaults without crash
+- [ ] Corrupted settings.json — reverts to defaults without crash
+- [ ] Closing app during debounce timer — OnClosing saves synchronously

--- a/src/Vido.Core/FileSystem/FileNode.cs
+++ b/src/Vido.Core/FileSystem/FileNode.cs
@@ -72,7 +72,7 @@ public sealed class FileNode : INotifyPropertyChanged
             : (Path.GetFileName(fullPath) ?? fullPath);
         IsDirectory = isDirectory;
         IsVideoFile = !isDirectory && VideoExtensions.Contains(
-            Path.GetExtension(fullPath).ToLowerInvariant());
+            Path.GetExtension(fullPath));
 
         // Directories get a placeholder child so the TreeView shows an expander arrow.
         if (isDirectory)

--- a/src/Vido.Core/Formatting/TimeFormatter.cs
+++ b/src/Vido.Core/Formatting/TimeFormatter.cs
@@ -1,0 +1,29 @@
+namespace Vido.Core.Formatting;
+
+/// <summary>
+/// Shared time-formatting utilities used across ViewModels.
+/// </summary>
+public static class TimeFormatter
+{
+    /// <summary>
+    /// Formats a <see cref="TimeSpan"/> for transport display (position/duration).
+    /// Uses "mm:ss" or "h:mm:ss" (no leading zero on hours).
+    /// </summary>
+    public static string Format(TimeSpan ts)
+    {
+        return ts.TotalHours >= 1
+            ? ts.ToString(@"h\:mm\:ss")
+            : ts.ToString(@"mm\:ss");
+    }
+
+    /// <summary>
+    /// Formats a <see cref="TimeSpan"/> for metadata display (status bar, details panel).
+    /// Uses "mm:ss" or "hh:mm:ss" (leading zero on hours).
+    /// </summary>
+    public static string FormatPadded(TimeSpan ts)
+    {
+        return ts.TotalHours >= 1
+            ? ts.ToString(@"hh\:mm\:ss")
+            : ts.ToString(@"mm\:ss");
+    }
+}

--- a/src/Vido.Core/Keyboard/KeyBinding.cs
+++ b/src/Vido.Core/Keyboard/KeyBinding.cs
@@ -18,30 +18,29 @@ public sealed class KeyBinding : IEquatable<KeyBinding>
     /// <summary>Whether Alt must be held.</summary>
     public bool Alt { get; }
 
+    private readonly string _displayString;
+
     public KeyBinding(string key, bool ctrl = false, bool shift = false, bool alt = false)
     {
         Key = key ?? throw new ArgumentNullException(nameof(key));
         Ctrl = ctrl;
         Shift = shift;
         Alt = alt;
+
+        // Pre-compute display string (immutable record)
+        var parts = new List<string>(4);
+        if (ctrl) parts.Add("Ctrl");
+        if (alt) parts.Add("Alt");
+        if (shift) parts.Add("Shift");
+        parts.Add(key);
+        _displayString = string.Join("+", parts);
     }
 
     /// <summary>
     /// Returns a human-readable display string (e.g., "Ctrl+Shift+O").
     /// Matches the format used in menu InputGestureText.
     /// </summary>
-    public string DisplayString
-    {
-        get
-        {
-            var parts = new List<string>(4);
-            if (Ctrl) parts.Add("Ctrl");
-            if (Alt) parts.Add("Alt");
-            if (Shift) parts.Add("Shift");
-            parts.Add(Key);
-            return string.Join("+", parts);
-        }
-    }
+    public string DisplayString => _displayString;
 
     public bool Equals(KeyBinding? other)
     {

--- a/src/Vido.Core/Playback/IVideoEngine.cs
+++ b/src/Vido.Core/Playback/IVideoEngine.cs
@@ -26,6 +26,9 @@ public interface IVideoEngine : IDisposable
     /// <summary>Whether playback loops when reaching the end.</summary>
     bool IsLooping { get; set; }
 
+    /// <summary>Playback speed multiplier (0.25–4.0). Default is 1.0.</summary>
+    double SpeedRatio { get; set; }
+
     /// <summary>Metadata for the currently loaded video, or null if none.</summary>
     VideoMetadata? CurrentMetadata { get; }
 

--- a/src/Vido.Core/Settings/AppSettings.cs
+++ b/src/Vido.Core/Settings/AppSettings.cs
@@ -7,7 +7,7 @@ namespace Vido.Core.Settings;
 public sealed class AppSettings
 {
     // --- Video Playback ---
-    public double Volume { get; set; } = 0.75;
+    public double Volume { get; set; } = 0.50;
     public bool IsMuted { get; set; } = false;
     public double PlaybackSpeed { get; set; } = 1.0;
     public bool LoopPlayback { get; set; } = false;
@@ -16,14 +16,13 @@ public sealed class AppSettings
     public bool SidebarVisible { get; set; } = true;
     public double SidebarWidth { get; set; } = 300;
     public bool StatusBarVisible { get; set; } = true;
-    public bool BottomPanelVisible { get; set; } = false;
+    public bool BottomPanelVisible { get; set; } = true;
+    public bool BottomPanelCollapsed { get; set; } = false;
     public double BottomPanelHeight { get; set; } = 200;
-    public bool RightPanelVisible { get; set; } = false;
+    public bool RightPanelVisible { get; set; } = true;
+    public bool RightPanelCollapsed { get; set; } = false;
     public double RightPanelWidth { get; set; } = 300;
 
     // --- File Explorer ---
     public bool ShowHiddenFiles { get; set; } = false;
-
-    // --- General ---
-    public bool ConfirmOnExit { get; set; } = false;
 }

--- a/src/Vido.Core/State/AppState.cs
+++ b/src/Vido.Core/State/AppState.cs
@@ -10,7 +10,7 @@ public sealed class AppState
     // --- Window Geometry ---
     public double WindowLeft { get; set; } = double.NaN;
     public double WindowTop { get; set; } = double.NaN;
-    public double WindowWidth { get; set; } = 2560;
+    public double WindowWidth { get; set; } = 1280;
     public double WindowHeight { get; set; } = 720;
     public bool IsMaximized { get; set; } = false;
 
@@ -28,4 +28,25 @@ public sealed class AppState
     /// These files are hidden (not deleted from disk) and persist across restarts.
     /// </summary>
     public List<string> HiddenFiles { get; set; } = [];
+
+    // --- Recent Files ---
+    /// <summary>
+    /// Most recently opened video file paths, newest first. Capped at 10.
+    /// </summary>
+    public List<string> RecentFiles { get; set; } = [];
+
+    /// <summary>Maximum number of recent files to retain.</summary>
+    public const int MaxRecentFiles = 10;
+
+    /// <summary>
+    /// Adds a file to the recent files list, moving it to the front if it already exists.
+    /// Trims the list to <see cref="MaxRecentFiles"/>.
+    /// </summary>
+    public void AddRecentFile(string filePath)
+    {
+        RecentFiles.RemoveAll(f => string.Equals(f, filePath, StringComparison.OrdinalIgnoreCase));
+        RecentFiles.Insert(0, filePath);
+        if (RecentFiles.Count > MaxRecentFiles)
+            RecentFiles.RemoveRange(MaxRecentFiles, RecentFiles.Count - MaxRecentFiles);
+    }
 }

--- a/src/Vido.Core/State/IStateService.cs
+++ b/src/Vido.Core/State/IStateService.cs
@@ -17,7 +17,14 @@ public interface IStateService
     Task LoadAsync();
 
     /// <summary>
-    /// Saves state to disk immediately.
+    /// Queues a debounced save to disk (500ms delay).
+    /// Multiple rapid calls coalesce into a single write.
+    /// </summary>
+    void QueueSave();
+
+    /// <summary>
+    /// Saves state to disk immediately, bypassing the debounce.
+    /// Used during application shutdown.
     /// </summary>
     Task SaveAsync();
 }

--- a/src/Vido.Services/Logging/LogService.cs
+++ b/src/Vido.Services/Logging/LogService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Vido.Core.Logging;
 
 namespace Vido.Services.Logging;
@@ -11,15 +10,17 @@ namespace Vido.Services.Logging;
 /// </summary>
 public sealed class LogService : ILogService
 {
-    private readonly ConcurrentBag<LogEntry> _entries = [];
-    private readonly object _eventLock = new();
+    private readonly List<LogEntry> _entries = [];
+    private readonly object _lock = new();
 
     public IReadOnlyList<LogEntry> Entries
     {
         get
         {
-            // Return chronologically ordered snapshot
-            return _entries.Reverse().ToList().AsReadOnly();
+            lock (_lock)
+            {
+                return _entries.ToList().AsReadOnly();
+            }
         }
     }
 
@@ -32,18 +33,21 @@ public sealed class LogService : ILogService
 
     public void Clear()
     {
-        // ConcurrentBag doesn't have Clear — drain it
-        while (_entries.TryTake(out _)) { }
+        lock (_lock)
+        {
+            _entries.Clear();
+        }
     }
 
     private void Log(LogLevel level, string message, string? source)
     {
         var entry = new LogEntry(DateTime.UtcNow, level, message, source);
-        _entries.Add(entry);
 
-        lock (_eventLock)
+        lock (_lock)
         {
-            EntryAdded?.Invoke(entry);
+            _entries.Add(entry);
         }
+
+        EntryAdded?.Invoke(entry);
     }
 }

--- a/src/Vido.Services/Menus/ContextMenuRegistry.cs
+++ b/src/Vido.Services/Menus/ContextMenuRegistry.cs
@@ -1,4 +1,3 @@
-using Vido.Core.FileSystem;
 using Vido.Core.Menus;
 
 namespace Vido.Services.Menus;

--- a/src/Vido.Services/Settings/SettingsService.cs
+++ b/src/Vido.Services/Settings/SettingsService.cs
@@ -10,11 +10,11 @@ namespace Vido.Services.Settings;
 /// </summary>
 public sealed class SettingsService : ISettingsService, IDisposable
 {
-    private static readonly string SettingsDir =
+    private static readonly string DefaultSettingsDir =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Vido");
 
-    private static readonly string SettingsPath =
-        Path.Combine(SettingsDir, "settings.json");
+    private readonly string _settingsDir;
+    private readonly string _settingsPath;
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -23,48 +23,67 @@ public sealed class SettingsService : ISettingsService, IDisposable
     };
 
     private readonly SemaphoreSlim _saveLock = new(1, 1);
+    private readonly object _debounceGuard = new();
     private CancellationTokenSource? _debounceCts;
     private const int DebounceMs = 500;
+
+    /// <summary>
+    /// Creates a settings service that persists to the default %APPDATA%/Vido directory.
+    /// </summary>
+    public SettingsService() : this(DefaultSettingsDir) { }
+
+    /// <summary>
+    /// Creates a settings service that persists to the specified directory.
+    /// Used for testing with isolated temp directories.
+    /// </summary>
+    public SettingsService(string settingsDirectory)
+    {
+        _settingsDir = settingsDirectory;
+        _settingsPath = Path.Combine(_settingsDir, "settings.json");
+    }
 
     public AppSettings Current { get; private set; } = new();
 
     public async Task LoadAsync()
     {
-        if (!File.Exists(SettingsPath))
+        if (!File.Exists(_settingsPath))
             return;
 
         try
         {
-            var json = await File.ReadAllTextAsync(SettingsPath);
+            var json = await File.ReadAllTextAsync(_settingsPath);
             var loaded = JsonSerializer.Deserialize<AppSettings>(json, JsonOptions);
             if (loaded is not null)
                 Current = loaded;
         }
-        catch
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or IOException)
         {
-            // Corrupted file — use defaults
+            // Corrupted or inaccessible file — use defaults
             Current = new AppSettings();
         }
     }
 
     public void QueueSave()
     {
-        _debounceCts?.Cancel();
-        _debounceCts = new CancellationTokenSource();
-        var token = _debounceCts.Token;
-
-        _ = Task.Run(async () =>
+        lock (_debounceGuard)
         {
-            try
+            _debounceCts?.Cancel();
+            _debounceCts = new CancellationTokenSource();
+            var token = _debounceCts.Token;
+
+            _ = Task.Run(async () =>
             {
-                await Task.Delay(DebounceMs, token);
-                await SaveAsync();
-            }
-            catch (TaskCanceledException)
-            {
-                // Debounce cancelled — a newer save was queued
-            }
-        }, token);
+                try
+                {
+                    await Task.Delay(DebounceMs, token);
+                    await SaveAsync();
+                }
+                catch (TaskCanceledException)
+                {
+                    // Debounce cancelled — a newer save was queued
+                }
+            }, token);
+        }
     }
 
     public async Task SaveAsync()
@@ -72,9 +91,9 @@ public sealed class SettingsService : ISettingsService, IDisposable
         await _saveLock.WaitAsync();
         try
         {
-            Directory.CreateDirectory(SettingsDir);
+            Directory.CreateDirectory(_settingsDir);
             var json = JsonSerializer.Serialize(Current, JsonOptions);
-            await File.WriteAllTextAsync(SettingsPath, json);
+            await File.WriteAllTextAsync(_settingsPath, json);
         }
         finally
         {

--- a/src/Vido.Services/State/StateService.cs
+++ b/src/Vido.Services/State/StateService.cs
@@ -7,8 +7,10 @@ namespace Vido.Services.State;
 /// <summary>
 /// JSON-based state persistence to %APPDATA%/Vido/state.json.
 /// Stores implicit application state (window geometry, last session, etc.).
+/// Supports debounced saving — multiple rapid <see cref="QueueSave"/> calls
+/// coalesce into a single disk write after 500ms of inactivity.
 /// </summary>
-public sealed class StateService : IStateService
+public sealed class StateService : IStateService, IDisposable
 {
     private static readonly string StateDir =
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Vido");
@@ -24,6 +26,9 @@ public sealed class StateService : IStateService
     };
 
     private readonly SemaphoreSlim _saveLock = new(1, 1);
+    private readonly object _debounceGuard = new();
+    private CancellationTokenSource? _debounceCts;
+    private const int DebounceMs = 500;
 
     public AppState Current { get; private set; } = new();
 
@@ -39,10 +44,33 @@ public sealed class StateService : IStateService
             if (loaded is not null)
                 Current = loaded;
         }
-        catch
+        catch (Exception ex) when (ex is System.Text.Json.JsonException or IOException)
         {
-            // Corrupted file — use defaults
+            // Corrupted or inaccessible file — use defaults
             Current = new AppState();
+        }
+    }
+
+    public void QueueSave()
+    {
+        lock (_debounceGuard)
+        {
+            _debounceCts?.Cancel();
+            _debounceCts = new CancellationTokenSource();
+            var token = _debounceCts.Token;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(DebounceMs, token);
+                    await SaveAsync();
+                }
+                catch (TaskCanceledException)
+                {
+                    // Debounce cancelled — a newer save was queued
+                }
+            }, token);
         }
     }
 
@@ -59,5 +87,12 @@ public sealed class StateService : IStateService
         {
             _saveLock.Release();
         }
+    }
+
+    public void Dispose()
+    {
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _saveLock.Dispose();
     }
 }

--- a/src/Vido.Services/Video/FFmpegVideoEngine.cs
+++ b/src/Vido.Services/Video/FFmpegVideoEngine.cs
@@ -21,7 +21,6 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     private int _videoStreamIndex = -1;
     private int _audioStreamIndex = -1;
     private AVStream* _videoStream;
-    private AVStream* _audioStream;
 
     // ── Audio resampling ──
     private SwrContext* _swrContext;
@@ -49,6 +48,7 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     private int _volume = 75;
     private bool _isMuted;
     private bool _isLooping;
+    private double _speedRatio = 1.0;
     private VideoMetadata? _currentMetadata;
     private bool _disposed;
     private readonly object _stateLock = new();
@@ -129,6 +129,25 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
     {
         get => _isLooping;
         set => _isLooping = value;
+    }
+
+    public double SpeedRatio
+    {
+        get => _speedRatio;
+        set
+        {
+            var clamped = Math.Clamp(value, 0.25, 4.0);
+            if (Math.Abs(clamped - _speedRatio) < 0.001) return;
+
+            // Snapshot current position before changing speed to prevent clock jumps
+            if (_playbackClock.IsRunning)
+            {
+                _clockOffset = GetClockPosition();
+                _playbackClock.Restart();
+            }
+
+            _speedRatio = clamped;
+        }
     }
 
     public VideoMetadata? CurrentMetadata => _currentMetadata;
@@ -285,8 +304,8 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         _audioStreamIndex = FindBestStream(AVMediaType.AVMEDIA_TYPE_AUDIO);
         if (_audioStreamIndex >= 0)
         {
-            _audioStream = _formatContext->streams[_audioStreamIndex];
-            _audioCodecContext = OpenCodec(_audioStream);
+            var audioStream = _formatContext->streams[_audioStreamIndex];
+            _audioCodecContext = OpenCodec(audioStream);
             InitializeAudioResampler();
             InitializeAudioRenderer();
         }
@@ -637,7 +656,7 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
 
     private TimeSpan GetClockPosition()
     {
-        return _clockOffset + _playbackClock.Elapsed;
+        return _clockOffset + TimeSpan.FromTicks((long)(_playbackClock.Elapsed.Ticks * _speedRatio));
     }
 
     private void StartPositionTimer()
@@ -749,7 +768,6 @@ public sealed unsafe class FFmpegVideoEngine : IVideoEngine
         _videoStreamIndex = -1;
         _audioStreamIndex = -1;
         _videoStream = null;
-        _audioStream = null;
 
         _currentMetadata = null;
         Duration = TimeSpan.Zero;

--- a/src/Vido.Services/Video/FrameConverter.cs
+++ b/src/Vido.Services/Video/FrameConverter.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using FFmpeg.AutoGen.Abstractions;
 using Vido.Core.Playback;
 

--- a/src/Vido.ViewModels/ActivityBarViewModel.cs
+++ b/src/Vido.ViewModels/ActivityBarViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vido.Core.Layout;
+using Vido.Core.Settings;
 
 namespace Vido.ViewModels;
 
@@ -10,11 +11,22 @@ namespace Vido.ViewModels;
 /// </summary>
 public partial class ActivityBarViewModel : ObservableObject
 {
+    private readonly ISettingsService? _settingsService;
+
     [ObservableProperty]
     private SidebarPanelKind _activePanel = SidebarPanelKind.Explorer;
 
     [ObservableProperty]
     private bool _isSidebarVisible = true;
+
+    public ActivityBarViewModel() : this(null) { }
+
+    public ActivityBarViewModel(ISettingsService? settingsService)
+    {
+        _settingsService = settingsService;
+        if (settingsService is not null)
+            _isSidebarVisible = settingsService.Current.SidebarVisible;
+    }
 
     /// <summary>
     /// Selects a panel. If the panel is already active, toggles the sidebar.
@@ -32,6 +44,21 @@ public partial class ActivityBarViewModel : ObservableObject
             ActivePanel = panel;
             IsSidebarVisible = true;
         }
+    }
+
+    /// <summary>
+    /// Sets the active panel without toggling visibility. Used for state restoration.
+    /// </summary>
+    public void SetActivePanel(SidebarPanelKind panel)
+    {
+        ActivePanel = panel;
+    }
+
+    partial void OnIsSidebarVisibleChanged(bool value)
+    {
+        if (_settingsService is null) return;
+        _settingsService.Current.SidebarVisible = value;
+        _settingsService.QueueSave();
     }
 
     /// <summary>

--- a/src/Vido.ViewModels/FileExplorerViewModel.cs
+++ b/src/Vido.ViewModels/FileExplorerViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vido.Core.FileSystem;
 using Vido.Core.Logging;
+using Vido.Core.Settings;
 using Vido.Core.State;
 
 namespace Vido.ViewModels;
@@ -16,6 +17,7 @@ public partial class FileExplorerViewModel : ObservableObject
 {
     private readonly IFileSystemService _fileSystemService;
     private readonly IStateService _stateService;
+    private readonly ISettingsService _settingsService;
     private readonly ILogService _logService;
 
     /// <summary>Root-level nodes displayed in the tree.</summary>
@@ -44,11 +46,14 @@ public partial class FileExplorerViewModel : ObservableObject
     [ObservableProperty]
     private bool _showHiddenFiles;
 
-    public FileExplorerViewModel(IFileSystemService fileSystemService, IStateService stateService, ILogService logService)
+    public FileExplorerViewModel(IFileSystemService fileSystemService, IStateService stateService,
+        ISettingsService settingsService, ILogService logService)
     {
         _fileSystemService = fileSystemService;
         _stateService = stateService;
+        _settingsService = settingsService;
         _logService = logService;
+        _showHiddenFiles = settingsService.Current.ShowHiddenFiles;
     }
 
     /// <summary>
@@ -111,6 +116,7 @@ public partial class FileExplorerViewModel : ObservableObject
             RootNodes.Add(node);
 
         _stateService.Current.LastOpenFolder = path;
+        _stateService.QueueSave();
         _logService.Info($"Folder opened: {path}", "Explorer");
     }
 
@@ -127,6 +133,7 @@ public partial class FileExplorerViewModel : ObservableObject
         HasFolderOpen = false;
         SelectedNode = null;
         _stateService.Current.LastOpenFolder = null;
+        _stateService.QueueSave();
         if (wasOpen is not null)
             _logService.Info("Folder closed", "Explorer");
     }
@@ -182,6 +189,8 @@ public partial class FileExplorerViewModel : ObservableObject
         if (!hiddenFiles.Contains(node.FullPath, StringComparer.OrdinalIgnoreCase))
             hiddenFiles.Add(node.FullPath);
 
+        _stateService.QueueSave();
+
         if (ShowHiddenFiles)
         {
             // Mark it hidden visually but keep in tree
@@ -206,6 +215,7 @@ public partial class FileExplorerViewModel : ObservableObject
         _stateService.Current.HiddenFiles.RemoveAll(
             p => string.Equals(p, node.FullPath, StringComparison.OrdinalIgnoreCase));
 
+        _stateService.QueueSave();
         node.IsHidden = false;
     }
 
@@ -226,9 +236,9 @@ public partial class FileExplorerViewModel : ObservableObject
                 UseShellExecute = true
             });
         }
-        catch
+        catch (Exception)
         {
-            // Silently ignore if explorer cannot be launched
+            // Explorer launch failed — non-critical, ignore
         }
     }
 
@@ -240,6 +250,8 @@ public partial class FileExplorerViewModel : ObservableObject
     public void ToggleShowHiddenFiles()
     {
         ShowHiddenFiles = !ShowHiddenFiles;
+        _settingsService.Current.ShowHiddenFiles = ShowHiddenFiles;
+        _settingsService.QueueSave();
         RefreshTree();
     }
 

--- a/src/Vido.ViewModels/MainWindowViewModel.cs
+++ b/src/Vido.ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vido.Core.Layout;
+using Vido.Core.Settings;
 
 namespace Vido.ViewModels;
 
@@ -11,6 +12,14 @@ namespace Vido.ViewModels;
 /// </summary>
 public partial class MainWindowViewModel : ObservableObject
 {
+    private readonly ISettingsService _settingsService;
+
+    /// <summary>
+    /// When true, property change handlers skip persisting to settings.
+    /// Used during fullscreen transitions to avoid saving transient UI state.
+    /// </summary>
+    public bool SuppressSettingsSave { get; set; }
+
     /// <summary>Well-known tab ID for the video player.</summary>
     public const string PlayerTabId = "Player";
 
@@ -92,8 +101,10 @@ public partial class MainWindowViewModel : ObservableObject
         if (newValue is not null) newValue.IsActive = true;
     }
 
-    public MainWindowViewModel()
+    public MainWindowViewModel(ISettingsService settingsService)
     {
+        _settingsService = settingsService;
+
         // The Player tab is always present, pinned leftmost, not closable
         var playerTab = new TabItemModel(PlayerTabId, "Player")
         {
@@ -110,11 +121,13 @@ public partial class MainWindowViewModel : ObservableObject
         BottomPanelTabs.Add(outputTab);
         ActiveBottomPanelTab = outputTab;
 
-        // Both panels start visible but collapsed
-        IsBottomPanelVisible = true;
-        IsBottomPanelCollapsed = true;
-        IsRightPanelVisible = true;
-        IsRightPanelCollapsed = true;
+        // Initialize panel state from persisted settings (use backing fields to avoid triggering saves)
+        var s = settingsService.Current;
+        _isBottomPanelVisible = s.BottomPanelVisible;
+        _isBottomPanelCollapsed = s.BottomPanelCollapsed;
+        _isRightPanelVisible = s.RightPanelVisible;
+        _isRightPanelCollapsed = s.RightPanelCollapsed;
+        _isStatusBarVisible = s.StatusBarVisible;
     }
 
     // ── Tab Commands ──
@@ -261,6 +274,41 @@ public partial class MainWindowViewModel : ObservableObject
     public void ToggleStatusBar()
     {
         IsStatusBarVisible = !IsStatusBarVisible;
+    }
+
+    partial void OnIsBottomPanelVisibleChanged(bool value)
+    {
+        if (SuppressSettingsSave) return;
+        _settingsService.Current.BottomPanelVisible = value;
+        _settingsService.QueueSave();
+    }
+
+    partial void OnIsRightPanelVisibleChanged(bool value)
+    {
+        if (SuppressSettingsSave) return;
+        _settingsService.Current.RightPanelVisible = value;
+        _settingsService.QueueSave();
+    }
+
+    partial void OnIsStatusBarVisibleChanged(bool value)
+    {
+        if (SuppressSettingsSave) return;
+        _settingsService.Current.StatusBarVisible = value;
+        _settingsService.QueueSave();
+    }
+
+    partial void OnIsBottomPanelCollapsedChanged(bool value)
+    {
+        if (SuppressSettingsSave) return;
+        _settingsService.Current.BottomPanelCollapsed = value;
+        _settingsService.QueueSave();
+    }
+
+    partial void OnIsRightPanelCollapsedChanged(bool value)
+    {
+        if (SuppressSettingsSave) return;
+        _settingsService.Current.RightPanelCollapsed = value;
+        _settingsService.QueueSave();
     }
 
     // ── Bottom Panel Tab Commands ──

--- a/src/Vido.ViewModels/OutputLogViewModel.cs
+++ b/src/Vido.ViewModels/OutputLogViewModel.cs
@@ -23,10 +23,6 @@ public partial class OutputLogViewModel : ObservableObject
     [ObservableProperty]
     private bool _isAutoScrollEnabled = true;
 
-    /// <summary>The currently selected minimum log level filter.</summary>
-    [ObservableProperty]
-    private LogLevel _selectedLevel = LogLevel.Debug;
-
     /// <summary>Whether the log has any entries (for empty state display).</summary>
     [ObservableProperty]
     private bool _hasEntries;
@@ -109,7 +105,6 @@ public partial class OutputLogViewModel : ObservableObject
     public void SetFilter(LogLevel level)
     {
         _minimumLevel = level;
-        SelectedLevel = level;
         FilterText = LevelToFilterText(level);
         RebuildFilteredEntries();
     }

--- a/src/Vido.ViewModels/StatusBarViewModel.cs
+++ b/src/Vido.ViewModels/StatusBarViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Vido.Core.Formatting;
 using Vido.Core.Layout;
 using Vido.Core.Playback;
 
@@ -177,12 +178,7 @@ public partial class StatusBarViewModel : ObservableObject, IDisposable
         collection.Add(item);
     }
 
-    internal static string FormatDuration(TimeSpan duration)
-    {
-        return duration.TotalHours >= 1
-            ? duration.ToString(@"hh\:mm\:ss")
-            : duration.ToString(@"mm\:ss");
-    }
+    internal static string FormatDuration(TimeSpan duration) => TimeFormatter.FormatPadded(duration);
 
     public void Dispose()
     {

--- a/src/Vido.ViewModels/VideoDetailsViewModel.cs
+++ b/src/Vido.ViewModels/VideoDetailsViewModel.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Vido.Core.Formatting;
 using Vido.Core.Playback;
 
 namespace Vido.ViewModels;
@@ -127,12 +128,7 @@ public partial class VideoDetailsViewModel : ObservableObject, IDisposable
         };
     }
 
-    internal static string FormatDuration(TimeSpan duration)
-    {
-        return duration.TotalHours >= 1
-            ? duration.ToString(@"hh\:mm\:ss")
-            : duration.ToString(@"mm\:ss");
-    }
+    internal static string FormatDuration(TimeSpan duration) => TimeFormatter.FormatPadded(duration);
 
     internal static string FormatBitrate(long bitsPerSecond)
     {

--- a/src/Vido.ViewModels/VideoPlayerViewModel.cs
+++ b/src/Vido.ViewModels/VideoPlayerViewModel.cs
@@ -2,8 +2,11 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Vido.Core.FileSystem;
+using Vido.Core.Formatting;
 using Vido.Core.Logging;
 using Vido.Core.Playback;
+using Vido.Core.Settings;
+using Vido.Core.State;
 
 namespace Vido.ViewModels;
 
@@ -15,8 +18,17 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
 {
     private readonly IVideoEngine _engine;
     private readonly ILogService _logService;
+    private readonly ISettingsService _settingsService;
+    private readonly IStateService _stateService;
     private bool _disposed;
     private bool _isSeeking;
+    private double _lastSavedPositionSeconds;
+
+    /// <summary>Seek slider range maximum (0 – SliderMaximum).</summary>
+    private const double SeekSliderMaximum = 1000.0;
+
+    /// <summary>Minimum playback change (seconds) before persisting position to state.</summary>
+    private const double PositionSaveIntervalSeconds = 5.0;
 
     // ── Observable state ──
 
@@ -47,6 +59,14 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     /// <summary>Whether shuffle mode is active.</summary>
     [ObservableProperty]
     private bool _isShuffling;
+
+    /// <summary>Current playback speed multiplier (0.25–4.0).</summary>
+    [ObservableProperty]
+    private double _playbackSpeed = 1.0;
+
+    /// <summary>Display text for the current playback speed (e.g. "1x", "2x").</summary>
+    [ObservableProperty]
+    private string _playbackSpeedText = "1x";
 
     /// <summary>Whether a video file is currently loaded.</summary>
     [ObservableProperty]
@@ -81,6 +101,16 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string? _currentFilePath;
 
+    // ── Resume Bar ──
+
+    /// <summary>Whether the resume playback prompt bar is visible.</summary>
+    [ObservableProperty]
+    private bool _showResumeBar;
+
+    /// <summary>Title text shown in the resume bar (e.g. the video file name).</summary>
+    [ObservableProperty]
+    private string _resumeBarTitle = string.Empty;
+
     /// <summary>
     /// Ordered list of all video files under the explorer root.
     /// Populated when the explorer root changes or a file is loaded.
@@ -105,13 +135,25 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     /// </summary>
     public event Action<FrameData>? FrameReady;
 
-    public VideoPlayerViewModel(IVideoEngine engine, ILogService logService)
+    public VideoPlayerViewModel(IVideoEngine engine, ILogService logService,
+        ISettingsService settingsService, IStateService stateService)
     {
         _engine = engine;
         _logService = logService;
-        Volume = _engine.Volume;
-        IsMuted = _engine.IsMuted;
-        IsLooping = _engine.IsLooping;
+        _settingsService = settingsService;
+        _stateService = stateService;
+
+        // Initialize from persisted settings (use backing fields to avoid triggering save handlers)
+        var settings = settingsService.Current;
+        _engine.Volume = (int)(settings.Volume * 100);
+        _engine.IsMuted = settings.IsMuted;
+        _engine.IsLooping = settings.LoopPlayback;
+        _volume = _engine.Volume;
+        _isMuted = _engine.IsMuted;
+        _isLooping = _engine.IsLooping;
+        _playbackSpeed = settings.PlaybackSpeed;
+        _playbackSpeedText = FormatSpeed(_playbackSpeed);
+        _engine.SpeedRatio = _playbackSpeed;
 
         _engine.StateChanged += OnEngineStateChanged;
         _engine.PositionChanged += OnEnginePositionChanged;
@@ -135,7 +177,15 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
         PositionText = FormatTime(position);
 
         if (Duration.TotalSeconds > 0)
-            SeekPosition = position.TotalSeconds / Duration.TotalSeconds * 1000.0;
+            SeekPosition = position.TotalSeconds / Duration.TotalSeconds * SeekSliderMaximum;
+
+        // Save position to state every N seconds of playback change
+        if (Math.Abs(position.TotalSeconds - _lastSavedPositionSeconds) >= PositionSaveIntervalSeconds)
+        {
+            _lastSavedPositionSeconds = position.TotalSeconds;
+            _stateService.Current.LastVideoPosition = position.TotalSeconds;
+            _stateService.QueueSave();
+        }
     }
 
     private void OnEngineFrameReady(FrameData frame)
@@ -167,6 +217,7 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     /// </summary>
     public async Task LoadAndPlayAsync(string filePath)
     {
+        ShowResumeBar = false;
         _logService.Info($"Loading video: {Path.GetFileName(filePath)}", "Player");
         await _engine.LoadAsync(filePath);
 
@@ -191,6 +242,95 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
 
         _engine.Play();
         _logService.Info($"Playing: {Path.GetFileName(filePath)} ({CurrentMetadata?.Resolution}, {FormatTime(Duration)})", "Player");
+
+        // Track last video and recent files
+        _lastSavedPositionSeconds = 0;
+        _stateService.Current.LastVideoPath = filePath;
+        _stateService.Current.LastVideoPosition = 0;
+        _stateService.Current.AddRecentFile(filePath);
+        _stateService.QueueSave();
+    }
+
+    /// <summary>
+    /// Restores the last played video from state, seeking to the saved position
+    /// and pausing. Shows a resume bar prompting the user to continue or dismiss.
+    /// </summary>
+    public async Task RestoreLastVideoAsync()
+    {
+        var lastPath = _stateService.Current.LastVideoPath;
+        if (string.IsNullOrEmpty(lastPath) || !File.Exists(lastPath))
+            return;
+
+        _logService.Info($"Restoring last video: {Path.GetFileName(lastPath)}", "Player");
+        await _engine.LoadAsync(lastPath);
+
+        CurrentFilePath = lastPath;
+        Duration = _engine.Duration;
+        DurationText = FormatTime(Duration);
+        CurrentMetadata = _engine.CurrentMetadata;
+        HasMedia = true;
+
+        BuildSiblingList(lastPath);
+
+        // Start playback so the decode thread renders a frame, then seek and pause.
+        // Without Play(), the decode thread never starts and Seek is a no-op,
+        // leaving a gray background.
+        var seekDone = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnSeekDone() => seekDone.TrySetResult();
+        _engine.SeekCompleted += OnSeekDone;
+
+        _engine.Play();
+
+        var savedPosition = _stateService.Current.LastVideoPosition;
+        if (savedPosition > 0 && Duration.TotalSeconds > 0)
+        {
+            var target = TimeSpan.FromSeconds(Math.Min(savedPosition, Duration.TotalSeconds));
+            _engine.Seek(target);
+            Position = target;
+            PositionText = FormatTime(target);
+            SeekPosition = target.TotalSeconds / Duration.TotalSeconds * SeekSliderMaximum;
+            _lastSavedPositionSeconds = target.TotalSeconds;
+        }
+        else
+        {
+            Position = TimeSpan.Zero;
+            PositionText = "00:00";
+            SeekPosition = 0;
+            // Seek to zero so SeekCompleted fires
+            _engine.Seek(TimeSpan.Zero);
+        }
+
+        // Wait for the seek to complete (frame is decoded and rendered), then pause
+        await Task.WhenAny(seekDone.Task, Task.Delay(2000));
+        _engine.SeekCompleted -= OnSeekDone;
+        _engine.Pause();
+
+        // Show the resume bar prompt
+        ResumeBarTitle = Path.GetFileName(lastPath);
+        ShowResumeBar = true;
+
+        _logService.Info($"Restored: {Path.GetFileName(lastPath)} at {PositionText}", "Player");
+    }
+
+    /// <summary>Accepts the resume prompt — continues playback from the restored position.</summary>
+    [RelayCommand]
+    public void ResumePlayback()
+    {
+        ShowResumeBar = false;
+        if (HasMedia)
+        {
+            _engine.Play();
+            _logService.Info("Resume accepted — playback started", "Player");
+        }
+    }
+
+    /// <summary>Dismisses the resume prompt — closes/unloads the video.</summary>
+    [RelayCommand]
+    public void DismissResume()
+    {
+        ShowResumeBar = false;
+        Stop();
+        _logService.Info("Resume dismissed — video unloaded", "Player");
     }
 
     /// <summary>Toggles between play and pause.</summary>
@@ -198,6 +338,13 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     public void PlayPause()
     {
         if (!HasMedia) return;
+
+        // If resume bar is visible, treat play/pause as accepting the resume
+        if (ShowResumeBar)
+        {
+            ResumePlayback();
+            return;
+        }
 
         if (State == PlaybackState.Playing)
         {
@@ -218,7 +365,6 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
         if (!HasMedia) return;
         _engine.Stop();
         _logService.Info("Playback stopped", "Player");
-        _logService.Info("Playback stopped", "Player");
         HasMedia = false;
         CurrentMetadata = null;
         CurrentFilePath = null;
@@ -227,6 +373,10 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
         PositionText = "00:00";
         DurationText = "00:00";
         SeekPosition = 0;
+
+        _stateService.Current.LastVideoPath = null;
+        _stateService.Current.LastVideoPosition = 0;
+        _stateService.QueueSave();
     }
 
     /// <summary>Skips to the previous video file in the folder (wraps around).</summary>
@@ -277,16 +427,23 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
         // Any manual volume adjustment should unmute
         if (IsMuted)
             IsMuted = false;
+
+        _settingsService.Current.Volume = value / 100.0;
+        _settingsService.QueueSave();
     }
 
     partial void OnIsMutedChanged(bool value)
     {
         _engine.IsMuted = value;
+        _settingsService.Current.IsMuted = value;
+        _settingsService.QueueSave();
     }
 
     partial void OnIsLoopingChanged(bool value)
     {
         _engine.IsLooping = value;
+        _settingsService.Current.LoopPlayback = value;
+        _settingsService.QueueSave();
     }
 
     partial void OnIsShufflingChanged(bool value)
@@ -295,6 +452,26 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
             BuildShufflePlaylist();
         else
             ClearShufflePlaylist();
+    }
+
+    partial void OnPlaybackSpeedChanged(double value)
+    {
+        _engine.SpeedRatio = value;
+        PlaybackSpeedText = FormatSpeed(value);
+        _settingsService.Current.PlaybackSpeed = value;
+        _settingsService.QueueSave();
+    }
+
+    /// <summary>Sets the playback speed to a specific value.</summary>
+    [RelayCommand]
+    public void SetPlaybackSpeed(double speed)
+    {
+        PlaybackSpeed = Math.Clamp(speed, 0.25, 4.0);
+    }
+
+    private static string FormatSpeed(double speed)
+    {
+        return speed == (int)speed ? $"{(int)speed}x" : $"{speed:0.##}x";
     }
 
     // ── Seek support ──
@@ -325,7 +502,7 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     {
         if (Duration.TotalSeconds > 0)
         {
-            var target = TimeSpan.FromSeconds(SeekPosition / 1000.0 * Duration.TotalSeconds);
+            var target = TimeSpan.FromSeconds(SeekPosition / SeekSliderMaximum * Duration.TotalSeconds);
             _engine.Seek(target);
             Position = target;
             PositionText = FormatTime(target);
@@ -387,7 +564,7 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
                 .OrderBy(f => f, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
-        catch
+        catch (Exception)
         {
             _siblingVideoFiles = [];
         }
@@ -476,12 +653,7 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
 
     // ── Formatting ──
 
-    internal static string FormatTime(TimeSpan ts)
-    {
-        if (ts.TotalHours >= 1)
-            return ts.ToString(@"h\:mm\:ss");
-        return ts.ToString(@"mm\:ss");
-    }
+    internal static string FormatTime(TimeSpan ts) => TimeFormatter.Format(ts);
 
     // ── Cleanup ──
 

--- a/src/Vido.Views/Controls/TitleBarView.xaml
+++ b/src/Vido.Views/Controls/TitleBarView.xaml
@@ -48,15 +48,17 @@
                 <MenuItem Header="Open _Folder..." InputGestureText="Ctrl+Shift+O"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           Click="OnOpenFolderClick" />
-                <MenuItem x:Name="CloseFolderMenuItem" Header="_Close Folder"
+                <MenuItem x:Name="CloseFolderMenuItem" Header="_Close Folder" InputGestureText="Ctrl+K"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           IsEnabled="False"
                           Click="OnCloseFolderClick" />
-                <MenuItem x:Name="RescanFolderMenuItem" Header="_Rescan Folder"
+                <MenuItem x:Name="RescanFolderMenuItem" Header="_Rescan Folder" InputGestureText="Ctrl+Shift+R"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           IsEnabled="False"
                           Click="OnRescanFolderClick" />
-                <MenuItem Header="_Recent Files" Style="{StaticResource SubmenuParentItemStyle}">
+                <MenuItem x:Name="RecentFilesMenu" Header="_Recent Files"
+                          Style="{StaticResource SubmenuParentItemStyle}"
+                          SubmenuOpened="OnRecentFilesSubmenuOpened">
                     <MenuItem Header="No recent files" Style="{StaticResource DropdownMenuItemStyle}"
                               IsEnabled="False" />
                 </MenuItem>
@@ -73,20 +75,19 @@
             </MenuItem>
 
             <!-- View -->
-            <MenuItem Header="_View" Style="{StaticResource TitleBarMenuItemStyle}">
-                <MenuItem Header="Toggle _Sidebar" InputGestureText="Ctrl+B"
+            <MenuItem Header="_View" Style="{StaticResource TitleBarMenuItemStyle}"
+                      SubmenuOpened="OnViewSubmenuOpened">
+                <MenuItem x:Name="ShowHideSidebarMenuItem"
+                          Header="_Show Sidebar" InputGestureText="Ctrl+B"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           Click="OnToggleSidebarClick" />
-                <MenuItem Header="Toggle S_tatus Bar"
+                <MenuItem x:Name="ShowHideStatusBarMenuItem"
+                          Header="Show S_tatus Bar"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           Click="OnToggleStatusBarClick" />
                 <MenuItem Header="_Fullscreen" InputGestureText="F11"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           Click="OnFullscreenClick" />
-                <MenuItem Header="Zoom _In" InputGestureText="Ctrl+="
-                          Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
-                <MenuItem Header="Zoom _Out" InputGestureText="Ctrl+-"
-                          Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
                 <MenuItem x:Name="RightPanelMenu"
                           Header="_Right Panel"
                           Style="{StaticResource SubmenuParentItemStyle}"
@@ -113,6 +114,12 @@
                               Style="{StaticResource DropdownMenuItemStyle}"
                               Click="OnToggleBottomPanelClick" />
                 </MenuItem>
+                <Separator Style="{StaticResource MenuSeparatorStyle}" />
+                <MenuItem x:Name="ShowHiddenFilesMenuItem"
+                          Header="Show _Hidden Files"
+                          Style="{StaticResource DropdownMenuItemStyle}"
+                          IsCheckable="True"
+                          Click="OnToggleShowHiddenFilesClick" />
             </MenuItem>
 
             <!-- Playback -->
@@ -132,12 +139,24 @@
                 <MenuItem Header="_Loop"
                           Style="{StaticResource DropdownMenuItemStyle}"
                           Click="OnLoopClick" />
-                <MenuItem Header="Playback _Speed" Style="{StaticResource SubmenuParentItemStyle}">
-                    <MenuItem Header="0.25x" Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
-                    <MenuItem Header="0.5x" Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
-                    <MenuItem Header="1.0x" Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
-                    <MenuItem Header="1.5x" Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
-                    <MenuItem Header="2.0x" Style="{StaticResource DropdownMenuItemStyle}" IsEnabled="False" />
+                <MenuItem Header="Playback _Speed" Style="{StaticResource SubmenuParentItemStyle}"
+                          SubmenuOpened="OnSpeedSubmenuOpened">
+                    <MenuItem Header="0.25x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="0.25" />
+                    <MenuItem Header="0.5x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="0.5" />
+                    <MenuItem Header="0.75x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="0.75" />
+                    <MenuItem Header="1x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="1.0" />
+                    <MenuItem Header="1.25x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="1.25" />
+                    <MenuItem Header="1.5x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="1.5" />
+                    <MenuItem Header="2x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="2.0" />
+                    <MenuItem Header="4x" Style="{StaticResource DropdownMenuItemStyle}"
+                              Click="OnSpeedMenuItemClick" Tag="4.0" />
                 </MenuItem>
             </MenuItem>
 

--- a/src/Vido.Views/Controls/TitleBarView.xaml.cs
+++ b/src/Vido.Views/Controls/TitleBarView.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -150,6 +151,15 @@ public partial class TitleBarView : UserControl
     /// <summary>Raised when View > Toggle Sidebar is clicked.</summary>
     public event Action? ToggleSidebarRequested;
 
+    /// <summary>Raised when View > Show Hidden Files is toggled.</summary>
+    public event Action? ToggleShowHiddenFilesRequested;
+
+    /// <summary>
+    /// Function that returns whether hidden files are currently shown.
+    /// Set by MainWindow so TitleBarView can sync the checkmark state.
+    /// </summary>
+    public Func<bool>? GetShowHiddenFiles { get; set; }
+
     // ── Playback menu events ──
 
     /// <summary>Raised when Playback > Play/Pause is clicked.</summary>
@@ -167,14 +177,42 @@ public partial class TitleBarView : UserControl
     /// <summary>Raised when Playback > Loop is clicked.</summary>
     public event Action? LoopRequested;
 
+    /// <summary>Raised when a playback speed is selected from the menu.</summary>
+    public event Action<double>? PlaybackSpeedSelected;
+
+    /// <summary>
+    /// Function that returns the current playback speed.
+    /// Set by MainWindow so TitleBarView can sync checkmarks.
+    /// </summary>
+    public Func<double>? GetPlaybackSpeed { get; set; }
+
     /// <summary>Raised when View > Fullscreen is clicked.</summary>
     public event Action? FullscreenRequested;
+
+    /// <summary>Raised when a recent file is selected from File > Recent Files.</summary>
+    public event Action<string>? RecentFileSelected;
+
+    /// <summary>Raised when File > Recent Files > Clear Watch History is clicked.</summary>
+    public event Action? ClearWatchHistoryRequested;
+
+    /// <summary>
+    /// Function that returns the current list of recent files.
+    /// Set by MainWindow so TitleBarView can populate the submenu without
+    /// directly depending on IStateService.
+    /// </summary>
+    public Func<IReadOnlyList<string>>? GetRecentFiles { get; set; }
 
     /// <summary>Whether the bottom panel is currently visible. Used to update the submenu text.</summary>
     private bool _isBottomPanelVisible;
 
     /// <summary>Whether the right panel is currently visible. Used to update the submenu text.</summary>
     private bool _isRightPanelVisible;
+
+    /// <summary>Whether the sidebar is currently visible. Used to update the submenu text.</summary>
+    private bool _isSidebarVisible;
+
+    /// <summary>Whether the status bar is currently visible. Used to update the submenu text.</summary>
+    private bool _isStatusBarVisible;
 
     /// <summary>
     /// Updates the Bottom Panel submenu state based on current panel visibility.
@@ -192,6 +230,24 @@ public partial class TitleBarView : UserControl
     public void SetRightPanelVisible(bool visible)
     {
         _isRightPanelVisible = visible;
+    }
+
+    /// <summary>
+    /// Updates the Sidebar submenu state based on current sidebar visibility.
+    /// Called by MainWindow when the sidebar visibility changes.
+    /// </summary>
+    public void SetSidebarVisible(bool visible)
+    {
+        _isSidebarVisible = visible;
+    }
+
+    /// <summary>
+    /// Updates the Status Bar submenu state based on current status bar visibility.
+    /// Called by MainWindow when the status bar visibility changes.
+    /// </summary>
+    public void SetStatusBarVisible(bool visible)
+    {
+        _isStatusBarVisible = visible;
     }
 
     private void OnBottomPanelSubmenuOpened(object sender, RoutedEventArgs e)
@@ -238,6 +294,18 @@ public partial class TitleBarView : UserControl
         ToggleSidebarRequested?.Invoke();
     }
 
+    private void OnViewSubmenuOpened(object sender, RoutedEventArgs e)
+    {
+        ShowHiddenFilesMenuItem.IsChecked = GetShowHiddenFiles?.Invoke() ?? false;
+        ShowHideSidebarMenuItem.Header = _isSidebarVisible ? "_Hide Sidebar" : "_Show Sidebar";
+        ShowHideStatusBarMenuItem.Header = _isStatusBarVisible ? "Hide S_tatus Bar" : "Show S_tatus Bar";
+    }
+
+    private void OnToggleShowHiddenFilesClick(object sender, RoutedEventArgs e)
+    {
+        ToggleShowHiddenFilesRequested?.Invoke();
+    }
+
     private void OnPlayPauseClick(object sender, RoutedEventArgs e)
     {
         PlayPauseRequested?.Invoke();
@@ -263,8 +331,79 @@ public partial class TitleBarView : UserControl
         LoopRequested?.Invoke();
     }
 
+    private void OnSpeedSubmenuOpened(object sender, RoutedEventArgs e)
+    {
+        if (sender is not MenuItem parent) return;
+        var currentSpeed = GetPlaybackSpeed?.Invoke() ?? 1.0;
+
+        foreach (var item in parent.Items.OfType<MenuItem>())
+        {
+            if (item.Tag is string tagStr && double.TryParse(tagStr,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var speed))
+            {
+                item.IsChecked = Math.Abs(currentSpeed - speed) < 0.01;
+            }
+        }
+    }
+
+    private void OnSpeedMenuItemClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem item && item.Tag is string tagStr
+            && double.TryParse(tagStr,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var speed))
+        {
+            PlaybackSpeedSelected?.Invoke(speed);
+        }
+    }
+
     private void OnFullscreenClick(object sender, RoutedEventArgs e)
     {
         FullscreenRequested?.Invoke();
+    }
+
+    private void OnRecentFilesSubmenuOpened(object sender, RoutedEventArgs e)
+    {
+        RecentFilesMenu.Items.Clear();
+
+        var recentFiles = GetRecentFiles?.Invoke();
+        if (recentFiles is null || recentFiles.Count == 0)
+        {
+            var empty = new MenuItem
+            {
+                Header = "No recent files",
+                IsEnabled = false,
+            };
+            empty.SetResourceReference(StyleProperty, "DropdownMenuItemStyle");
+            RecentFilesMenu.Items.Add(empty);
+            return;
+        }
+
+        foreach (var filePath in recentFiles)
+        {
+            var item = new MenuItem
+            {
+                Header = System.IO.Path.GetFileName(filePath),
+                ToolTip = filePath,
+            };
+            item.SetResourceReference(StyleProperty, "DropdownMenuItemStyle");
+            var path = filePath; // capture for closure
+            item.Click += (_, _) => RecentFileSelected?.Invoke(path);
+            RecentFilesMenu.Items.Add(item);
+        }
+
+        // Add separator and Clear Watch History
+        var separator = new Separator();
+        separator.SetResourceReference(StyleProperty, "MenuSeparatorStyle");
+        RecentFilesMenu.Items.Add(separator);
+
+        var clearItem = new MenuItem
+        {
+            Header = "Clear Watch History",
+        };
+        clearItem.SetResourceReference(StyleProperty, "DropdownMenuItemStyle");
+        clearItem.Click += (_, _) => ClearWatchHistoryRequested?.Invoke();
+        RecentFilesMenu.Items.Add(clearItem);
     }
 }

--- a/src/Vido.Views/Controls/VideoPlayerControl.xaml
+++ b/src/Vido.Views/Controls/VideoPlayerControl.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="PlayerStyles.xaml" />
+                <ResourceDictionary Source="../Themes/ContextMenuStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
@@ -41,6 +42,57 @@
                Stretch="Uniform"
                RenderOptions.BitmapScalingMode="HighQuality"
                Visibility="Collapsed" />
+
+        <!-- ═══ Resume playback bar ═══ -->
+        <Border x:Name="ResumeBar"
+                VerticalAlignment="Top"
+                HorizontalAlignment="Stretch"
+                Background="{DynamicResource StatusBarBackgroundBrush}"
+                Visibility="{Binding ShowResumeBar, Converter={StaticResource BoolToVis}}"
+                Padding="12,5">
+            <DockPanel>
+                <!-- Right-side buttons -->
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                    <StackPanel.Resources>
+                        <Style x:Key="ResumeBarButtonStyle" TargetType="Button">
+                            <Setter Property="FontFamily" Value="Segoe UI" />
+                            <Setter Property="FontSize" Value="12" />
+                            <Setter Property="Foreground" Value="#ffffff" />
+                            <Setter Property="Cursor" Value="Hand" />
+                            <Setter Property="Padding" Value="12,3" />
+                            <Setter Property="Margin" Value="0,0,4,0" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="Button">
+                                        <Border x:Name="Bd" Background="Transparent"
+                                                Padding="{TemplateBinding Padding}"
+                                                CornerRadius="3">
+                                            <ContentPresenter HorizontalAlignment="Center"
+                                                              VerticalAlignment="Center" />
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="Bd" Property="Background" Value="#33ffffff" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </StackPanel.Resources>
+                    <Button Content="Yes" Style="{StaticResource ResumeBarButtonStyle}"
+                            Command="{Binding ResumePlaybackCommand}" />
+                    <Button Content="No" Style="{StaticResource ResumeBarButtonStyle}"
+                            Command="{Binding DismissResumeCommand}" />
+                </StackPanel>
+                <!-- Resume text -->
+                <TextBlock VerticalAlignment="Center"
+                           Foreground="#ffffff"
+                           FontFamily="Segoe UI" FontSize="12">
+                    <Run Text="Resume playback of " /><Run Text="{Binding ResumeBarTitle, Mode=OneWay}" FontWeight="SemiBold" /><Run Text="?" />
+                </TextBlock>
+            </DockPanel>
+        </Border>
 
         <!-- ═══ Transport controls overlay ═══ -->
         <!-- In normal mode: docked at bottom with solid bg. In fullscreen: overlaid with gradient bg. -->
@@ -184,6 +236,39 @@
                                   Fill="Transparent"
                                   Stretch="Uniform" Width="14" Height="14" />
                         </ToggleButton>
+
+                        <!-- Playback speed -->
+                        <Button x:Name="SpeedButton"
+                                Style="{StaticResource TransportButtonStyle}"
+                                Width="Auto" MinWidth="28" Height="28" Padding="4,5"
+                                ToolTip="Playback Speed"
+                                Click="OnSpeedButtonClick">
+                            <TextBlock Text="{Binding PlaybackSpeedText}"
+                                       FontSize="11" FontWeight="SemiBold"
+                                       Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" />
+                            <Button.ContextMenu>
+                                <ContextMenu x:Name="SpeedContextMenu"
+                                             Style="{StaticResource DarkContextMenuStyle}"
+                                             Opened="OnSpeedContextMenuOpened">
+                                    <MenuItem Header="0.25x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="0.25" />
+                                    <MenuItem Header="0.5x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="0.5" />
+                                    <MenuItem Header="0.75x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="0.75" />
+                                    <MenuItem Header="1x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="1.0" />
+                                    <MenuItem Header="1.25x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="1.25" />
+                                    <MenuItem Header="1.5x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="1.5" />
+                                    <MenuItem Header="2x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="2.0" />
+                                    <MenuItem Header="4x" Style="{StaticResource ContextMenuItemStyle}"
+                                              Click="OnSpeedItemClick" Tag="4.0" />
+                                </ContextMenu>
+                            </Button.ContextMenu>
+                        </Button>
 
                         <!-- Mute toggle -->
                         <Button Style="{StaticResource TransportButtonStyle}"

--- a/src/Vido.Views/Controls/VideoPlayerControl.xaml.cs
+++ b/src/Vido.Views/Controls/VideoPlayerControl.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -279,6 +280,46 @@ public partial class VideoPlayerControl : UserControl
             current = VisualTreeHelper.GetParent(current);
         }
         return false;
+    }
+
+    // ── Playback speed ──
+
+    private void OnSpeedButtonClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.ContextMenu is not null)
+        {
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.Placement = System.Windows.Controls.Primitives.PlacementMode.Top;
+            button.ContextMenu.IsOpen = true;
+        }
+    }
+
+    private void OnSpeedContextMenuOpened(object sender, RoutedEventArgs e)
+    {
+        if (sender is not ContextMenu menu || DataContext is not VideoPlayerViewModel vm)
+            return;
+
+        foreach (var item in menu.Items.OfType<MenuItem>())
+        {
+            if (item.Tag is string tagStr && double.TryParse(tagStr,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var speed))
+            {
+                item.IsChecked = Math.Abs(vm.PlaybackSpeed - speed) < 0.01;
+            }
+        }
+    }
+
+    private void OnSpeedItemClick(object sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem item && item.Tag is string tagStr
+            && double.TryParse(tagStr,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var speed)
+            && DataContext is VideoPlayerViewModel vm)
+        {
+            vm.SetPlaybackSpeed(speed);
+        }
     }
 
     // ── Fullscreen overlay mode ──

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
@@ -108,6 +109,7 @@ public partial class MainWindow : Window
         SetupKeyboardShortcuts();
         SetupFileExplorer();
         RestoreWindowState();
+        RestoreLayoutState();
 
         _logService.Info("Vido started", "App");
     }
@@ -155,7 +157,7 @@ public partial class MainWindow : Window
 
     private void SetupLayout()
     {
-        _activityBarViewModel = new ActivityBarViewModel();
+        _activityBarViewModel = new ActivityBarViewModel(_settingsService);
         _sidebarViewModel = new SidebarViewModel();
 
         ActivityBar.DataContext = _activityBarViewModel;
@@ -256,6 +258,18 @@ public partial class MainWindow : Window
         // File operations
         _keyboardShortcutService.Register(
             new KeyBinding("O", ctrl: true, shift: true), "vido.openFolder", ShowOpenFolderDialog);
+        _keyboardShortcutService.Register(
+            new KeyBinding("K", ctrl: true), "vido.closeFolder", () =>
+            {
+                if (_fileExplorerViewModel.HasFolderOpen)
+                    OnFolderClosed();
+            });
+        _keyboardShortcutService.Register(
+            new KeyBinding("R", ctrl: true, shift: true), "vido.rescanFolder", () =>
+            {
+                if (_fileExplorerViewModel.HasFolderOpen)
+                    OnFolderRescanned();
+            });
 
         // Fullscreen
         _keyboardShortcutService.Register(
@@ -460,10 +474,12 @@ public partial class MainWindow : Window
         SidebarColumn.MaxWidth = 0;
 
         // Hide bottom panel, right panel, and status bar via VM properties
-        // so UpdateXxxVisibility handlers fire correctly on restore
+        // Suppress settings save — these are transient fullscreen changes, not user preferences
+        _mainWindowViewModel.SuppressSettingsSave = true;
         _mainWindowViewModel.IsBottomPanelVisible = false;
         _mainWindowViewModel.IsRightPanelVisible = false;
         _mainWindowViewModel.IsStatusBarVisible = false;
+        _mainWindowViewModel.SuppressSettingsSave = false;
 
         // Force video tab active — fullscreen should always show the video player
         _preFullscreenActiveTabId = _mainWindowViewModel.ActiveTab?.Id;
@@ -556,12 +572,14 @@ public partial class MainWindow : Window
             OnPanelChanged(this, new RoutedEventArgs());
         }
 
-        // Restore panels
+        // Restore panels — suppress save since we're restoring to the already-persisted state
+        _mainWindowViewModel.SuppressSettingsSave = true;
         _mainWindowViewModel.IsBottomPanelVisible = _preFullscreenBottomPanelVisible;
         _mainWindowViewModel.IsBottomPanelCollapsed = _preFullscreenBottomPanelCollapsed;
         _mainWindowViewModel.IsRightPanelVisible = _preFullscreenRightPanelVisible;
         _mainWindowViewModel.IsRightPanelCollapsed = _preFullscreenRightPanelCollapsed;
         _mainWindowViewModel.IsStatusBarVisible = _preFullscreenStatusBarVisible;
+        _mainWindowViewModel.SuppressSettingsSave = false;
 
         // Restore window geometry
         WindowState = _preFullscreenWindowState;
@@ -782,12 +800,23 @@ public partial class MainWindow : Window
         // Wire fullscreen menu event
         TitleBar.FullscreenRequested += ToggleFullscreen;
 
+        // Wire recent files
+        TitleBar.GetRecentFiles = () => _stateService.Current.RecentFiles;
+        TitleBar.RecentFileSelected += path => SafeFireAndForget(OnRecentFileSelected(path));
+        TitleBar.ClearWatchHistoryRequested += OnClearWatchHistory;
+
+        // Wire show hidden files
+        TitleBar.GetShowHiddenFiles = () => _fileExplorerViewModel.ShowHiddenFiles;
+        TitleBar.ToggleShowHiddenFilesRequested += () => _fileExplorerViewModel.ToggleShowHiddenFiles();
+
         // Wire playback menu events
         TitleBar.PlayPauseRequested += () => _videoPlayerViewModel.PlayPause();
         TitleBar.StopRequested += () => _videoPlayerViewModel.Stop();
         TitleBar.SkipForwardRequested += () => SafeFireAndForget(_videoPlayerViewModel.SkipNext());
         TitleBar.SkipBackwardRequested += () => SafeFireAndForget(_videoPlayerViewModel.SkipPrevious());
         TitleBar.LoopRequested += () => _videoPlayerViewModel.ToggleLoop();
+        TitleBar.PlaybackSpeedSelected += speed => _videoPlayerViewModel.SetPlaybackSpeed(speed);
+        TitleBar.GetPlaybackSpeed = () => _videoPlayerViewModel.PlaybackSpeed;
 
         // Sync panel visibility state to title bar for dynamic menu text
         _mainWindowViewModel.PropertyChanged += (_, e) =>
@@ -796,11 +825,25 @@ public partial class MainWindow : Window
                 TitleBar.SetBottomPanelVisible(_mainWindowViewModel.IsBottomPanelVisible);
             else if (e.PropertyName == nameof(MainWindowViewModel.IsRightPanelVisible))
                 TitleBar.SetRightPanelVisible(_mainWindowViewModel.IsRightPanelVisible);
+            else if (e.PropertyName == nameof(MainWindowViewModel.IsStatusBarVisible))
+                TitleBar.SetStatusBarVisible(_mainWindowViewModel.IsStatusBarVisible);
         };
+
+        // Sync sidebar visibility to title bar
+        if (_activityBarViewModel is not null)
+        {
+            _activityBarViewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(ActivityBarViewModel.IsSidebarVisible))
+                    TitleBar.SetSidebarVisible(_activityBarViewModel.IsSidebarVisible);
+            };
+            TitleBar.SetSidebarVisible(_activityBarViewModel.IsSidebarVisible);
+        }
 
         // Initialize title bar panel visibility state
         TitleBar.SetBottomPanelVisible(_mainWindowViewModel.IsBottomPanelVisible);
         TitleBar.SetRightPanelVisible(_mainWindowViewModel.IsRightPanelVisible);
+        TitleBar.SetStatusBarVisible(_mainWindowViewModel.IsStatusBarVisible);
 
         // Wire the "Open Folder" button inside the explorer panel
         _fileExplorerPanel.OpenFolderRequested += ShowOpenFolderDialog;
@@ -867,6 +910,24 @@ public partial class MainWindow : Window
     {
         _fileExplorerViewModel.RescanFolder();
         _logService.Info("Folder rescanned", "Explorer");
+    }
+
+    private async Task OnRecentFileSelected(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            _logService.Error($"Recent file not found: {filePath}", "App");
+            return;
+        }
+
+        _mainWindowViewModel.ActivateTab(MainWindowViewModel.PlayerTabId);
+        await _videoPlayerViewModel.LoadAndPlayAsync(filePath);
+    }
+
+    private void OnClearWatchHistory()
+    {
+        _stateService.Current.RecentFiles.Clear();
+        _stateService.QueueSave();
     }
 
     private async void OnPlayFileRequested(Core.FileSystem.FileNode node)
@@ -1030,7 +1091,7 @@ public partial class MainWindow : Window
         {
             Sidebar.Visibility = Visibility.Visible;
             SidebarSplitter.Visibility = Visibility.Visible;
-            SidebarColumn.Width = new GridLength(300);
+            SidebarColumn.Width = new GridLength(_settingsService.Current.SidebarWidth);
             SidebarColumn.MinWidth = 170;
             SidebarColumn.MaxWidth = 600;
             _sidebarViewModel.SetPanel(_activityBarViewModel.ActivePanel);
@@ -1106,6 +1167,47 @@ public partial class MainWindow : Window
     }
 
     /// <summary>
+    /// Restores layout dimensions (sidebar width, panel heights) from persisted settings.
+    /// Called after RestoreWindowState so the window geometry is already set.
+    /// </summary>
+    private void RestoreLayoutState()
+    {
+        var settings = _settingsService.Current;
+
+        // Restore remembered dimensions for panels
+        _bottomPanelHeight = settings.BottomPanelHeight;
+        _rightPanelWidth = settings.RightPanelWidth;
+
+        // Restore sidebar width — applied when sidebar visibility fires via OnPanelChanged
+        // The sidebar visibility itself is restored by the activity bar view model.
+
+        // Restore active sidebar panel from state
+        var state = _stateService.Current;
+        if (_activityBarViewModel is not null && !string.IsNullOrEmpty(state.ActiveSidebarPanel))
+        {
+            if (Enum.TryParse<SidebarPanelKind>(state.ActiveSidebarPanel, out var panel))
+            {
+                _activityBarViewModel.SetActivePanel(panel);
+                // Refresh sidebar content to match the restored panel
+                OnPanelChanged(this, new RoutedEventArgs());
+            }
+        }
+
+        // Restore last video (paused at saved position)
+        Loaded += async (_, _) =>
+        {
+            try
+            {
+                await _videoPlayerViewModel.RestoreLastVideoAsync();
+            }
+            catch (Exception ex)
+            {
+                _logService.Error($"Failed to restore last video: {ex.Message}", "App");
+            }
+        };
+    }
+
+    /// <summary>
     /// Captures current window geometry into AppState for persistence.
     /// Uses RestoreBounds when maximized to save the normal-state geometry.
     /// If in fullscreen, saves the pre-fullscreen geometry instead.
@@ -1134,6 +1236,17 @@ public partial class MainWindow : Window
             state.WindowWidth = bounds.Width;
             state.WindowHeight = bounds.Height;
         }
+
+        // Save layout dimensions to settings
+        var settings = _settingsService.Current;
+        if (_activityBarViewModel is not null)
+        {
+            state.ActiveSidebarPanel = _activityBarViewModel.ActivePanel.ToString();
+        }
+        if (SidebarColumn.Width.Value > 0)
+            settings.SidebarWidth = SidebarColumn.Width.Value;
+        settings.BottomPanelHeight = _bottomPanelHeight;
+        settings.RightPanelWidth = _rightPanelWidth;
     }
 
     #endregion

--- a/src/Vido.Views/Panels/FileExplorerPanel.xaml
+++ b/src/Vido.Views/Panels/FileExplorerPanel.xaml
@@ -59,7 +59,8 @@
 
             <!-- Context menu for tree background -->
             <ContextMenu x:Key="TreeBackgroundContextMenu"
-                         Style="{StaticResource DarkContextMenuStyle}">
+                         Style="{StaticResource DarkContextMenuStyle}"
+                         Opened="OnTreeBackgroundContextMenuOpened">
                 <MenuItem Header="Open Folder..."
                           Style="{StaticResource ContextMenuItemStyle}"
                           Click="OnContextOpenFolderClick" />

--- a/src/Vido.Views/Panels/FileExplorerPanel.xaml.cs
+++ b/src/Vido.Views/Panels/FileExplorerPanel.xaml.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -183,6 +184,21 @@ public partial class FileExplorerPanel : UserControl
     }
 
     // ─── Background context menu handlers ───────────────────────────
+
+    private void OnTreeBackgroundContextMenuOpened(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is FileExplorerViewModel vm && sender is ContextMenu menu)
+        {
+            foreach (var item in menu.Items.OfType<MenuItem>())
+            {
+                if (item.Name == "ContextShowHiddenFiles")
+                {
+                    item.IsChecked = vm.ShowHiddenFiles;
+                    break;
+                }
+            }
+        }
+    }
 
     private void OnContextOpenFolderClick(object sender, RoutedEventArgs e)
     {

--- a/src/Vido.Views/Themes/MenuStyles.xaml
+++ b/src/Vido.Views/Themes/MenuStyles.xaml
@@ -230,4 +230,21 @@
         </Setter>
     </Style>
 
+    <!-- Separator style for dropdown menus -->
+    <Style x:Key="MenuSeparatorStyle" TargetType="Separator">
+        <Setter Property="Height" Value="1" />
+        <Setter Property="Margin" Value="8,2" />
+        <Setter Property="Background" Value="{DynamicResource PrimaryBorderBrush}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Separator">
+                    <Border Height="1"
+                            Margin="{TemplateBinding Margin}"
+                            Background="{TemplateBinding Background}"
+                            SnapsToDevicePixels="True" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/tests/Vido.Tests/EventBusTests.cs
+++ b/tests/Vido.Tests/EventBusTests.cs
@@ -103,7 +103,7 @@ public sealed class EventBusTests
     }
 
     [Fact]
-    public void ConcurrentPublishAndSubscribe_DoesNotThrow()
+    public async Task ConcurrentPublishAndSubscribe_DoesNotThrow()
     {
         var count = 0;
         var tasks = new List<Task>();
@@ -118,7 +118,7 @@ public sealed class EventBusTests
             }));
         }
 
-        Task.WaitAll(tasks.ToArray());
+        await Task.WhenAll(tasks);
         // Just verifying no exceptions — count is non-deterministic
         Assert.True(count >= 0);
     }

--- a/tests/Vido.Tests/FileExplorerViewModelTests.cs
+++ b/tests/Vido.Tests/FileExplorerViewModelTests.cs
@@ -1,6 +1,7 @@
 using NSubstitute;
 using Vido.Core.FileSystem;
 using Vido.Core.Logging;
+using Vido.Core.Settings;
 using Vido.Core.State;
 using Vido.ViewModels;
 using Xunit;
@@ -11,14 +12,17 @@ public sealed class FileExplorerViewModelTests
 {
     private readonly IFileSystemService _fileSystemService = Substitute.For<IFileSystemService>();
     private readonly IStateService _stateService = Substitute.For<IStateService>();
+    private readonly ISettingsService _settingsService = Substitute.For<ISettingsService>();
     private readonly ILogService _logService = Substitute.For<ILogService>();
+    private readonly AppSettings _appSettings = new();
     private readonly AppState _appState = new();
     private readonly FileExplorerViewModel _sut;
 
     public FileExplorerViewModelTests()
     {
         _stateService.Current.Returns(_appState);
-        _sut = new FileExplorerViewModel(_fileSystemService, _stateService, _logService);
+        _settingsService.Current.Returns(_appSettings);
+        _sut = new FileExplorerViewModel(_fileSystemService, _stateService, _settingsService, _logService);
     }
 
     [Fact]

--- a/tests/Vido.Tests/MainWindowViewModelTests.cs
+++ b/tests/Vido.Tests/MainWindowViewModelTests.cs
@@ -1,4 +1,6 @@
+using NSubstitute;
 using Vido.Core.Layout;
+using Vido.Core.Settings;
 using Vido.ViewModels;
 using Xunit;
 
@@ -10,7 +12,19 @@ namespace Vido.Tests;
 /// </summary>
 public class MainWindowViewModelTests
 {
-    private readonly MainWindowViewModel _sut = new();
+    private readonly ISettingsService _settingsService;
+    private readonly MainWindowViewModel _sut;
+
+    public MainWindowViewModelTests()
+    {
+        _settingsService = Substitute.For<ISettingsService>();
+        _settingsService.Current.Returns(new AppSettings
+        {
+            BottomPanelVisible = true,
+            RightPanelVisible = true
+        });
+        _sut = new MainWindowViewModel(_settingsService);
+    }
 
     // ── Constructor / Initial State ──
 
@@ -39,10 +53,35 @@ public class MainWindowViewModelTests
     [Fact]
     public void Constructor_PanelsVisibleButCollapsedByDefault()
     {
-        Assert.True(_sut.IsBottomPanelVisible);
-        Assert.True(_sut.IsBottomPanelCollapsed);
-        Assert.True(_sut.IsRightPanelVisible);
-        Assert.True(_sut.IsRightPanelCollapsed);
+        // Create a VM with explicit collapsed=true to test the "collapsed but visible" state
+        var settingsSvc = Substitute.For<ISettingsService>();
+        settingsSvc.Current.Returns(new AppSettings
+        {
+            BottomPanelVisible = true,
+            BottomPanelCollapsed = true,
+            RightPanelVisible = true,
+            RightPanelCollapsed = true
+        });
+        var vm = new MainWindowViewModel(settingsSvc);
+
+        Assert.True(vm.IsBottomPanelVisible);
+        Assert.True(vm.IsBottomPanelCollapsed);
+        Assert.True(vm.IsRightPanelVisible);
+        Assert.True(vm.IsRightPanelCollapsed);
+    }
+
+    [Fact]
+    public void Constructor_PanelsVisibleAndExpanded_WhenDefaultSettings()
+    {
+        // Default AppSettings now has panels visible + expanded
+        var settingsSvc = Substitute.For<ISettingsService>();
+        settingsSvc.Current.Returns(new AppSettings());
+        var vm = new MainWindowViewModel(settingsSvc);
+
+        Assert.True(vm.IsBottomPanelVisible);
+        Assert.False(vm.IsBottomPanelCollapsed);
+        Assert.True(vm.IsRightPanelVisible);
+        Assert.False(vm.IsRightPanelCollapsed);
     }
 
     // ── OpenTab ──

--- a/tests/Vido.Tests/OutputLogViewModelTests.cs
+++ b/tests/Vido.Tests/OutputLogViewModelTests.cs
@@ -47,7 +47,6 @@ public sealed class OutputLogViewModelTests
     public void InitialState_FilterIsAll()
     {
         Assert.Equal("All", _sut.FilterText);
-        Assert.Equal(LogLevel.Debug, _sut.SelectedLevel);
     }
 
     // ── Loading existing entries ──
@@ -132,23 +131,18 @@ public sealed class OutputLogViewModelTests
     {
         // Initial: All (Debug)
         Assert.Equal("All", _sut.FilterText);
-        Assert.Equal(LogLevel.Debug, _sut.SelectedLevel);
 
         _sut.CycleFilter();
         Assert.Equal("Info+", _sut.FilterText);
-        Assert.Equal(LogLevel.Info, _sut.SelectedLevel);
 
         _sut.CycleFilter();
         Assert.Equal("Warn+", _sut.FilterText);
-        Assert.Equal(LogLevel.Warning, _sut.SelectedLevel);
 
         _sut.CycleFilter();
         Assert.Equal("Errors", _sut.FilterText);
-        Assert.Equal(LogLevel.Error, _sut.SelectedLevel);
 
         _sut.CycleFilter();
         Assert.Equal("All", _sut.FilterText);
-        Assert.Equal(LogLevel.Debug, _sut.SelectedLevel);
     }
 
     [Fact]
@@ -218,7 +212,6 @@ public sealed class OutputLogViewModelTests
     {
         _sut.SetFilter(LogLevel.Error);
 
-        Assert.Equal(LogLevel.Error, _sut.SelectedLevel);
         Assert.Equal("Errors", _sut.FilterText);
     }
 

--- a/tests/Vido.Tests/SettingsServiceTests.cs
+++ b/tests/Vido.Tests/SettingsServiceTests.cs
@@ -40,17 +40,16 @@ public sealed class SettingsServiceTests : IDisposable
     {
         var svc = new SettingsService();
 
-        Assert.Equal(0.75, svc.Current.Volume);
+        Assert.Equal(0.50, svc.Current.Volume);
         Assert.False(svc.Current.IsMuted);
         Assert.Equal(1.0, svc.Current.PlaybackSpeed);
         Assert.False(svc.Current.LoopPlayback);
         Assert.True(svc.Current.SidebarVisible);
         Assert.Equal(300, svc.Current.SidebarWidth);
         Assert.True(svc.Current.StatusBarVisible);
-        Assert.False(svc.Current.BottomPanelVisible);
-        Assert.False(svc.Current.RightPanelVisible);
+        Assert.True(svc.Current.BottomPanelVisible);
+        Assert.True(svc.Current.RightPanelVisible);
         Assert.False(svc.Current.ShowHiddenFiles);
-        Assert.False(svc.Current.ConfirmOnExit);
     }
 
     [Fact]

--- a/tests/Vido.Tests/StatePersistenceTests.cs
+++ b/tests/Vido.Tests/StatePersistenceTests.cs
@@ -1,0 +1,222 @@
+using NSubstitute;
+using Vido.Core.Settings;
+using Vido.Core.State;
+using Vido.ViewModels;
+using Xunit;
+
+namespace Vido.Tests;
+
+/// <summary>
+/// Tests for vi-016: State persistence — verifies that settings and state
+/// are saved when properties change and restored on construction.
+/// </summary>
+public sealed class StatePersistenceTests
+{
+    // ── AppState.AddRecentFile ──
+
+    [Fact]
+    public void AddRecentFile_AddsToFront()
+    {
+        var state = new AppState();
+        state.AddRecentFile(@"C:\a.mp4");
+        state.AddRecentFile(@"C:\b.mp4");
+
+        Assert.Equal(2, state.RecentFiles.Count);
+        Assert.Equal(@"C:\b.mp4", state.RecentFiles[0]);
+        Assert.Equal(@"C:\a.mp4", state.RecentFiles[1]);
+    }
+
+    [Fact]
+    public void AddRecentFile_MovesDuplicateToFront()
+    {
+        var state = new AppState();
+        state.AddRecentFile(@"C:\a.mp4");
+        state.AddRecentFile(@"C:\b.mp4");
+        state.AddRecentFile(@"C:\a.mp4");
+
+        Assert.Equal(2, state.RecentFiles.Count);
+        Assert.Equal(@"C:\a.mp4", state.RecentFiles[0]);
+        Assert.Equal(@"C:\b.mp4", state.RecentFiles[1]);
+    }
+
+    [Fact]
+    public void AddRecentFile_TrimsToMax()
+    {
+        var state = new AppState();
+        for (int i = 0; i < 15; i++)
+            state.AddRecentFile($@"C:\video{i}.mp4");
+
+        Assert.Equal(AppState.MaxRecentFiles, state.RecentFiles.Count);
+        Assert.Equal(@"C:\video14.mp4", state.RecentFiles[0]);
+    }
+
+    [Fact]
+    public void AddRecentFile_CaseInsensitiveDedupe()
+    {
+        var state = new AppState();
+        state.AddRecentFile(@"C:\Video.MP4");
+        state.AddRecentFile(@"c:\video.mp4");
+
+        Assert.Single(state.RecentFiles);
+        Assert.Equal(@"c:\video.mp4", state.RecentFiles[0]);
+    }
+
+    // ── MainWindowViewModel persists panel visibility ──
+
+    [Fact]
+    public void MainWindowVM_ToggleBottomPanel_SavesSettings()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings { BottomPanelVisible = true });
+        var vm = new MainWindowViewModel(settingsService);
+
+        vm.ToggleBottomPanel(); // false
+        settingsService.Received().QueueSave();
+        Assert.False(settingsService.Current.BottomPanelVisible);
+    }
+
+    [Fact]
+    public void MainWindowVM_ToggleRightPanel_SavesSettings()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings { RightPanelVisible = true });
+        var vm = new MainWindowViewModel(settingsService);
+
+        vm.ToggleRightPanel(); // false
+        settingsService.Received().QueueSave();
+        Assert.False(settingsService.Current.RightPanelVisible);
+    }
+
+    [Fact]
+    public void MainWindowVM_ToggleStatusBar_SavesSettings()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings());
+        var vm = new MainWindowViewModel(settingsService);
+
+        vm.ToggleStatusBar(); // false
+        settingsService.Received().QueueSave();
+        Assert.False(settingsService.Current.StatusBarVisible);
+    }
+
+    [Fact]
+    public void MainWindowVM_RestoresPanelState_FromSettings()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings
+        {
+            BottomPanelVisible = false,
+            RightPanelVisible = false,
+            StatusBarVisible = false
+        });
+
+        var vm = new MainWindowViewModel(settingsService);
+
+        Assert.False(vm.IsBottomPanelVisible);
+        Assert.False(vm.IsRightPanelVisible);
+        Assert.False(vm.IsStatusBarVisible);
+    }
+
+    // ── ActivityBarViewModel persists sidebar visibility ──
+
+    [Fact]
+    public void ActivityBarVM_RestoresSidebarVisibility()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings { SidebarVisible = false });
+
+        var vm = new ActivityBarViewModel(settingsService);
+
+        Assert.False(vm.IsSidebarVisible);
+    }
+
+    [Fact]
+    public void ActivityBarVM_SidebarToggle_SavesSettings()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings { SidebarVisible = true });
+        var vm = new ActivityBarViewModel(settingsService);
+
+        vm.IsSidebarVisible = false;
+        settingsService.Received().QueueSave();
+        Assert.False(settingsService.Current.SidebarVisible);
+    }
+
+    [Fact]
+    public void ActivityBarVM_SetActivePanel_DoesNotToggleVisibility()
+    {
+        var settingsService = Substitute.For<ISettingsService>();
+        settingsService.Current.Returns(new AppSettings());
+        var vm = new ActivityBarViewModel(settingsService);
+
+        vm.SetActivePanel(Core.Layout.SidebarPanelKind.Explorer);
+        Assert.True(vm.IsSidebarVisible); // unchanged
+    }
+
+    // ── State round-trip with RecentFiles ──
+
+    [Fact]
+    public async Task StateService_SaveAndLoad_RoundTripsRecentFiles()
+    {
+        var svc = new Vido.Services.State.StateService();
+        svc.Current.AddRecentFile(@"C:\a.mp4");
+        svc.Current.AddRecentFile(@"C:\b.mp4");
+
+        await svc.SaveAsync();
+
+        var svc2 = new Vido.Services.State.StateService();
+        await svc2.LoadAsync();
+
+        Assert.Equal(2, svc2.Current.RecentFiles.Count);
+        Assert.Equal(@"C:\b.mp4", svc2.Current.RecentFiles[0]);
+        Assert.Equal(@"C:\a.mp4", svc2.Current.RecentFiles[1]);
+    }
+
+    // ── Settings round-trip ──
+
+    [Fact]
+    public async Task SettingsService_SaveAndLoad_RoundTrips()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "VidoTest_" + Guid.NewGuid().ToString("N"));
+        try
+        {
+        var svc = new Vido.Services.Settings.SettingsService(tempDir);
+        svc.Current.Volume = 0.42;
+        svc.Current.IsMuted = true;
+        svc.Current.LoopPlayback = true;
+        svc.Current.SidebarVisible = false;
+        svc.Current.SidebarWidth = 250;
+        svc.Current.BottomPanelVisible = true;
+        svc.Current.BottomPanelCollapsed = false;
+        svc.Current.BottomPanelHeight = 150;
+        svc.Current.RightPanelVisible = true;
+        svc.Current.RightPanelCollapsed = false;
+        svc.Current.RightPanelWidth = 350;
+        svc.Current.StatusBarVisible = false;
+        svc.Current.ShowHiddenFiles = true;
+
+        await svc.SaveAsync();
+
+        var svc2 = new Vido.Services.Settings.SettingsService(tempDir);
+        await svc2.LoadAsync();
+
+        Assert.Equal(0.42, svc2.Current.Volume);
+        Assert.True(svc2.Current.IsMuted);
+        Assert.True(svc2.Current.LoopPlayback);
+        Assert.False(svc2.Current.SidebarVisible);
+        Assert.Equal(250, svc2.Current.SidebarWidth);
+        Assert.True(svc2.Current.BottomPanelVisible);
+        Assert.False(svc2.Current.BottomPanelCollapsed);
+        Assert.Equal(150, svc2.Current.BottomPanelHeight);
+        Assert.True(svc2.Current.RightPanelVisible);
+        Assert.False(svc2.Current.RightPanelCollapsed);
+        Assert.Equal(350, svc2.Current.RightPanelWidth);
+        Assert.False(svc2.Current.StatusBarVisible);
+        Assert.True(svc2.Current.ShowHiddenFiles);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/Vido.Tests/StateServiceTests.cs
+++ b/tests/Vido.Tests/StateServiceTests.cs
@@ -14,7 +14,7 @@ public sealed class StateServiceTests
     {
         var svc = new StateService();
 
-        Assert.Equal(2560, svc.Current.WindowWidth);
+        Assert.Equal(1280, svc.Current.WindowWidth);
         Assert.Equal(720, svc.Current.WindowHeight);
         Assert.True(double.IsNaN(svc.Current.WindowLeft));
         Assert.True(double.IsNaN(svc.Current.WindowTop));

--- a/tests/Vido.Tests/StatusBarViewModelTests.cs
+++ b/tests/Vido.Tests/StatusBarViewModelTests.cs
@@ -2,6 +2,8 @@ using NSubstitute;
 using Vido.Core.Layout;
 using Vido.Core.Logging;
 using Vido.Core.Playback;
+using Vido.Core.Settings;
+using Vido.Core.State;
 using Vido.ViewModels;
 using Xunit;
 
@@ -15,6 +17,8 @@ public class StatusBarViewModelTests : IDisposable
 {
     private readonly IVideoEngine _engine;
     private readonly ILogService _logService;
+    private readonly ISettingsService _settingsService;
+    private readonly IStateService _stateService;
     private readonly VideoPlayerViewModel _playerVm;
     private readonly StatusBarViewModel _sut;
 
@@ -39,8 +43,12 @@ public class StatusBarViewModelTests : IDisposable
     {
         _engine = Substitute.For<IVideoEngine>();
         _logService = Substitute.For<ILogService>();
+        _settingsService = Substitute.For<ISettingsService>();
+        _settingsService.Current.Returns(new AppSettings());
+        _stateService = Substitute.For<IStateService>();
+        _stateService.Current.Returns(new AppState());
         _engine.Volume.Returns(75);
-        _playerVm = new VideoPlayerViewModel(_engine, _logService);
+        _playerVm = new VideoPlayerViewModel(_engine, _logService, _settingsService, _stateService);
         _sut = new StatusBarViewModel(_playerVm);
     }
 

--- a/tests/Vido.Tests/VideoDetailsViewModelTests.cs
+++ b/tests/Vido.Tests/VideoDetailsViewModelTests.cs
@@ -1,6 +1,8 @@
 using NSubstitute;
 using Vido.Core.Logging;
 using Vido.Core.Playback;
+using Vido.Core.Settings;
+using Vido.Core.State;
 using Vido.ViewModels;
 using Xunit;
 
@@ -15,6 +17,8 @@ public class VideoDetailsViewModelTests : IDisposable
 {
     private readonly IVideoEngine _engine;
     private readonly ILogService _logService;
+    private readonly ISettingsService _settingsService;
+    private readonly IStateService _stateService;
     private readonly VideoPlayerViewModel _playerVm;
     private readonly VideoDetailsViewModel _sut;
 
@@ -39,8 +43,12 @@ public class VideoDetailsViewModelTests : IDisposable
     {
         _engine = Substitute.For<IVideoEngine>();
         _logService = Substitute.For<ILogService>();
+        _settingsService = Substitute.For<ISettingsService>();
+        _settingsService.Current.Returns(new AppSettings());
+        _stateService = Substitute.For<IStateService>();
+        _stateService.Current.Returns(new AppState());
         _engine.Volume.Returns(75);
-        _playerVm = new VideoPlayerViewModel(_engine, _logService);
+        _playerVm = new VideoPlayerViewModel(_engine, _logService, _settingsService, _stateService);
         _sut = new VideoDetailsViewModel(_playerVm);
     }
 

--- a/tests/Vido.Tests/VideoPlayerViewModelTests.cs
+++ b/tests/Vido.Tests/VideoPlayerViewModelTests.cs
@@ -1,6 +1,8 @@
 using NSubstitute;
 using Vido.Core.Logging;
 using Vido.Core.Playback;
+using Vido.Core.Settings;
+using Vido.Core.State;
 using Vido.ViewModels;
 using Xunit;
 
@@ -14,16 +16,22 @@ public class VideoPlayerViewModelTests : IDisposable
 {
     private readonly IVideoEngine _engine;
     private readonly ILogService _logService;
+    private readonly ISettingsService _settingsService;
+    private readonly IStateService _stateService;
     private readonly VideoPlayerViewModel _sut;
 
     public VideoPlayerViewModelTests()
     {
         _engine = Substitute.For<IVideoEngine>();
         _logService = Substitute.For<ILogService>();
+        _settingsService = Substitute.For<ISettingsService>();
+        _settingsService.Current.Returns(new AppSettings());
+        _stateService = Substitute.For<IStateService>();
+        _stateService.Current.Returns(new AppState());
         _engine.Volume.Returns(75);
         _engine.IsMuted.Returns(false);
         _engine.IsLooping.Returns(false);
-        _sut = new VideoPlayerViewModel(_engine, _logService);
+        _sut = new VideoPlayerViewModel(_engine, _logService, _settingsService, _stateService);
     }
 
     // ── Initial State ──
@@ -49,7 +57,7 @@ public class VideoPlayerViewModelTests : IDisposable
     [Fact]
     public void InitialVolume_InheritsFromEngine()
     {
-        Assert.Equal(75, _sut.Volume);
+        Assert.Equal(50, _sut.Volume);
     }
 
     [Fact]


### PR DESCRIPTION
- Added functionality to persist and restore user settings including panel visibility, sidebar width, and playback settings.
- Introduced methods to manage recent files in the application state, ensuring duplicates are handled and the list is trimmed to a maximum length.
- Enhanced the VideoPlayerControl with a resume playback bar and playback speed options, including a context menu for speed selection.
- Updated MainWindow and ActivityBar view models to support new settings and state persistence features.
- Added automated tests to verify state persistence behavior and settings round-trip serialization.
- Created a TimeFormatter utility for consistent time display formatting across the application.