### PR TITLE
feat(vi-019): Plugin Manager UI, Sample Plugin & End-to-End Validation

### DIFF
--- a/Context/PLUGIN_TESTING_GUIDE.md
+++ b/Context/PLUGIN_TESTING_GUIDE.md
@@ -1,0 +1,345 @@
+# Plugin Testing Guide
+
+> **vi-019** — Plugin Manager UI, Sample Plugin & End-to-End Validation
+
+This document provides step-by-step instructions for testing the Plugin Manager
+UI and the Sample Plugin in a running instance of Vido.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Setting Up the Sample Plugin](#2-setting-up-the-sample-plugin)
+3. [Configuring the Registry URL](#3-configuring-the-registry-url)
+4. [Browsing & Installing from the Plugin Manager](#4-browsing--installing-from-the-plugin-manager)
+5. [Verifying All Contributed UI Elements](#5-verifying-all-contributed-ui-elements)
+6. [Testing Plugin Settings](#6-testing-plugin-settings)
+7. [Testing Enable / Disable Toggle](#7-testing-enable--disable-toggle)
+8. [Testing Uninstall](#8-testing-uninstall)
+9. [Testing the Detail Panel](#9-testing-the-detail-panel)
+10. [Troubleshooting](#10-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| .NET 8 SDK | Required to build both Vido and the sample plugin |
+| PowerShell 5.1+ | Required to run `package.ps1` |
+| Vido source tree | Checked out at `c:\source\vido` (or equivalent) |
+| Sample plugin source | Checked out at `c:\source\vido-sample-plugin` |
+
+---
+
+## 2. Setting Up the Sample Plugin
+
+### 2a — Build the Plugin Zip
+
+```powershell
+cd c:\source\vido-sample-plugin
+.\package.ps1
+```
+
+This produces `vido-sample-plugin-1.0.0.zip` in the project root.
+
+### 2b — Create a Local Registry
+
+The sample plugin ships with a `registry.json` in its root directory. For local
+testing, we use a `file://` URL pointing to this file.
+
+Determine the absolute path of the registry file:
+
+```powershell
+# Example on Windows:
+$registryPath = (Resolve-Path "c:\source\vido-sample-plugin\registry.json").Path
+$fileUrl = "file:///$($registryPath -replace '\\','/')"
+Write-Host "Registry URL: $fileUrl"
+```
+
+**Important**: Update the `downloadUrl` in `registry.json` to point to the local
+zip file using a `file://` URL:
+
+```json
+"downloadUrl": "file:///C:/source/vido-sample-plugin/vido-sample-plugin-1.0.0.zip"
+```
+
+Save the file. The Plugin Manager will fetch this registry and use the local zip
+for installation.
+
+---
+
+## 3. Configuring the Registry URL
+
+1. Launch Vido.
+2. Open **Settings** (click the gear icon in the activity bar, or press `Ctrl+,`).
+3. Scroll to the **Plugins** section.
+4. In the **Plugin Registry URLs** list, click **Add** and paste the `file://`
+   URL from step 2b.
+5. Save settings.
+
+Alternatively, edit `%APPDATA%\Vido\settings.json` directly and add the URL to
+the `PluginRegistryUrls` array:
+
+```json
+{
+  "PluginRegistryUrls": [
+    "https://plugins.vido.app/registry",
+    "file:///C:/source/vido-sample-plugin/registry.json"
+  ]
+}
+```
+
+---
+
+## 4. Browsing & Installing from the Plugin Manager
+
+### 4a — Open the Plugin Manager
+
+1. Click the **Extensions** icon (puzzle piece) in the activity bar on the left.
+2. The Plugin Manager sidebar panel should appear.
+
+**Expected**:
+- A search bar at the top with a magnifying glass icon.
+- A registry source dropdown (defaulting to "All").
+- An **INSTALLED** section (may be empty) with a chevron and count badge.
+- An **AVAILABLE** section listing the Sample Plugin with a count badge of `1`.
+
+### 4b — Search
+
+1. Type `sample` in the search bar.
+2. The AVAILABLE section should show only the "Sample Plugin" entry.
+3. Clear the search bar — all plugins should reappear.
+4. Type `nonexistent` — both sections should be empty (count badges show `0`).
+
+### 4c — Registry Dropdown
+
+1. Click the registry dropdown.
+2. You should see: **All**, **Vido Plugin Registry** (from the local file).
+3. Select the specific registry name — only plugins from that registry appear.
+4. Select **All** again to restore the full list.
+
+### 4d — Install the Sample Plugin
+
+1. In the AVAILABLE section, click the blue **Install** button on the Sample
+   Plugin item.
+2. The button should show a busy state briefly.
+
+**Expected after install**:
+- The plugin moves from AVAILABLE to INSTALLED.
+- The INSTALLED count badge increments.
+- The AVAILABLE count badge decrements.
+- A detail tab opens for the Sample Plugin in the main panel.
+- The plugin status shows "Enabled".
+
+---
+
+## 5. Verifying All Contributed UI Elements
+
+After installing, verify each of the nine extension points:
+
+| # | Extension Point | How to Verify | Expected Result |
+|---|----------------|---------------|-----------------|
+| 1 | **Sidebar Panel** | Look for a new icon in the activity bar labeled "Sample Panel" | A panel displays with plugin info text |
+| 2 | **Bottom Panel Tab** | Check the bottom panel tabs for "Sample Log" | Tab shows timestamped activation message |
+| 3 | **Right Panel Tab** | Check the right panel tabs for "Sample Info" | Tab shows read-only plugin properties |
+| 4 | **Status Bar Item** | Look at the right side of the status bar | Displays "Hello, Vido!" (or "Sample Plugin v1.0" if greeting disabled) |
+| 5 | **Toolbar Button** | Look for the Sample Plugin button in the title bar | Click it → message appears in Output log |
+| 6 | **Context Menu** | Right-click any file in the File Explorer | "Hello from Plugin" menu item appears; clicking logs the filename |
+| 7 | **File Handler** | Create a file named `test.sample` in the explorer and double-click it | Message "Opened sample file: test.sample" appears in Output log |
+| 8 | **File Icon** | Look at the `test.sample` file in the explorer | It should display the custom icon (or a fallback if icon file is absent) |
+| 9 | **Keyboard Shortcut** | Press `Ctrl+Shift+H` | "Hello from keyboard shortcut!" appears in Output log |
+
+---
+
+## 6. Testing Plugin Settings
+
+### 6a — Open Settings
+
+1. In the Plugin Manager sidebar, click the **settings cog** icon on the Sample Plugin.
+2. The detail tab should open and switch to the **Settings** tab.
+
+Alternatively:
+1. Click the plugin item to open the detail panel.
+2. Click the **Settings** tab.
+
+### 6b — Verify Settings Display
+
+**Expected sections and controls**:
+
+| Section | Setting | Control Type | Default |
+|---------|---------|-------------|---------|
+| Display | Enable Greeting | Boolean dropdown (True/False) | `True` |
+| Display | Greeting Text | Text input | `Hello, Vido!` |
+| Advanced | Refresh Interval (seconds) | Number input | `30` |
+| Advanced | Log Level | Enum dropdown (Debug, Info, Warning, Error) | `Info` |
+
+Each setting should show its **title** in bold and its **description** below in
+secondary text. Sections should have a divider line and header text.
+
+### 6c — Modify Settings
+
+1. Change **Enable Greeting** from `True` to `False`.
+2. Change **Greeting Text** to `Hey there!`.
+3. Change **Refresh Interval** to `10`.
+4. Change **Log Level** to `Debug`.
+
+**Expected**:
+- Each change is auto-saved immediately (no save button needed).
+- The Output log shows "Setting changed: 'enableGreeting'" etc.
+- The status bar item updates (if greeting is disabled, shows "Sample Plugin v1.0").
+
+### 6d — Verify Persistence
+
+1. Close and reopen Vido.
+2. Open the Sample Plugin settings.
+3. All four settings should retain the values you set.
+4. **Exception**: `refreshInterval` has `forceOverride: true`, so it resets to `30`
+   on every plugin activation.
+
+---
+
+## 7. Testing Enable / Disable Toggle
+
+1. In the Plugin Manager sidebar, find the Sample Plugin in the INSTALLED
+   section.
+2. The status should show "Enabled".
+3. Click the **Disable** button (or toggle).
+
+**Expected**:
+- Status changes to "Disabled".
+- The Output log shows "Sample Plugin deactivated."
+- All contributed UI elements (sidebar panel, tabs, status bar item, context
+  menu item, toolbar button, keyboard shortcut) are removed / no longer
+  functional.
+
+4. Click **Enable**.
+
+**Expected**:
+- Status returns to "Enabled".
+- All contributed UI elements reappear.
+- The Output log shows "Sample Plugin activated successfully."
+
+---
+
+## 8. Testing Uninstall
+
+1. In the Plugin Manager sidebar, click the red **Uninstall** button on the
+   Sample Plugin.
+
+**Expected**:
+- The plugin moves from INSTALLED to AVAILABLE.
+- Count badges update.
+- All contributed UI elements are removed.
+- The plugin directory at `%APPDATA%\Vido\plugins\com.vido.sample-plugin\` is
+  deleted (or has a `.uninstall` marker if DLLs are locked).
+
+2. If a `.uninstall` marker was created, restart Vido.
+
+**Expected after restart**:
+- The plugin directory is fully removed on startup.
+- The plugin appears only in AVAILABLE.
+
+---
+
+## 9. Testing the Detail Panel
+
+### 9a — Open the Detail Panel
+
+1. Click on any plugin item in the Plugin Manager sidebar.
+2. A new tab opens in the main panel area with the plugin's detail view.
+
+### 9b — Header
+
+**Expected**:
+- 64×64 icon (or placeholder).
+- Plugin name in large bold text.
+- Publisher name with a verified badge (blue circle + checkmark) if the plugin
+  came from the official registry.
+- Description text.
+- Action buttons:
+  - **Available plugin**: Blue "Install" button.
+  - **Installed + enabled**: Red "Uninstall" button, red "Disable" button, settings gear.
+  - **Installed + disabled**: Red "Uninstall" button, blue "Enable" button, settings gear.
+
+### 9c — Tabbed Content
+
+| Tab | Expected Content |
+|-----|-----------------|
+| **Details** | Plugin's `README.md` content (rendered as plain text), or placeholder if absent |
+| **Changelog** | Plugin's `CHANGELOG.md` content, or placeholder if absent |
+| **Settings** | All four settings with proper type-specific controls (see Section 6) |
+
+### 9d — Right Metadata Pane
+
+**Expected** (at ~25% width on the right side):
+- **Version**: e.g., `1.0.0`
+- **Tags**: e.g., `sample, demo, reference, all-extensions`
+- **Last Updated**: e.g., `2025-01-15`
+- **License**: e.g., `MIT`
+
+### 9e — Action Button Reactivity
+
+1. Click "Install" on an available plugin → buttons should change to "Uninstall" + "Disable" + settings gear.
+2. Click "Disable" → button changes to "Enable".
+3. Click "Enable" → button changes back to "Disable".
+4. Click "Uninstall" → buttons change to "Install".
+
+---
+
+## 10. Troubleshooting
+
+### DLL Locking on Uninstall
+
+**Symptom**: Uninstall fails; a `.uninstall` marker file is created.
+
+**Cause**: .NET holds assembly locks on loaded plugin DLLs.
+
+**Solution**: Restart Vido. The `CleanupPendingUninstalls()` method runs on
+startup and removes marked directories.
+
+### Registry Fetch Fails
+
+**Symptom**: AVAILABLE section is empty; no error visible.
+
+**Cause**: Network error or malformed URL.
+
+**Solution**:
+1. Check the Output log for errors like `Failed to fetch registry from '...'`.
+2. Verify the URL is correct and accessible.
+3. For `file://` URLs, ensure the path uses forward slashes (`/`) and the file
+   exists.
+4. Verify `registry.json` is valid JSON (run `Test-Json (Get-Content registry.json -Raw)`).
+
+### Plugin Doesn't Appear After Install
+
+**Symptom**: Plugin zip extracted but plugin doesn't load.
+
+**Cause**: Missing or malformed `plugin.json`, or wrong `entryPoint` / `pluginClass`.
+
+**Solution**:
+1. Navigate to `%APPDATA%\Vido\plugins\com.vido.sample-plugin\`.
+2. Verify `plugin.json` exists and is valid.
+3. Verify the DLL named in `entryPoint` exists.
+4. Verify `pluginClass` matches the fully-qualified class name.
+5. Check the Output log for activation errors.
+
+### Settings Not Persisting
+
+**Symptom**: Settings revert to defaults on restart.
+
+**Cause**: The setting may have `forceOverride: true` in the manifest.
+
+**Solution**: Check the plugin's `plugin.json` → `contributes.settings` for the
+`forceOverride` flag on the affected setting.
+
+### Icon Not Displaying
+
+**Symptom**: Plugin icon shows as a placeholder rectangle.
+
+**Cause**: Icon file does not exist at the declared path.
+
+**Solution**: Ensure the icon files declared in the manifest (`icons/sample-sidebar.png`,
+`icons/sample-toolbar.png`, `icons/sample-file.png`) exist in the plugin directory.
+For the sample plugin, create placeholder PNG files in the `icons/` folder.

--- a/src/Vido.App/App.xaml.cs
+++ b/src/Vido.App/App.xaml.cs
@@ -113,6 +113,7 @@ public partial class App : Application
         services.AddSingleton<PluginHost.ContributionRegistry>();
         services.AddSingleton<IContributionRegistry>(sp => sp.GetRequiredService<PluginHost.ContributionRegistry>());
         services.AddSingleton<IPluginHost, PluginHost.PluginHost>();
+        services.AddSingleton<IPluginInstaller, Vido.Services.Plugin.PluginInstaller>();
 
         // ViewModels
         services.AddSingleton<FileExplorerViewModel>();

--- a/src/Vido.Core/Plugin/IPluginHost.cs
+++ b/src/Vido.Core/Plugin/IPluginHost.cs
@@ -35,4 +35,10 @@ public interface IPluginHost
     /// Returns the list of disabled plugin IDs from persisted settings.
     /// </summary>
     IReadOnlyList<string> GetDisabledPluginIds();
+
+    /// <summary>
+    /// Gets or creates a settings store for the specified plugin.
+    /// Used by the Plugin Manager UI to display and edit plugin settings.
+    /// </summary>
+    IPluginSettingsStore GetSettingsStore(string pluginId);
 }

--- a/src/Vido.Core/Plugin/IPluginInstaller.cs
+++ b/src/Vido.Core/Plugin/IPluginInstaller.cs
@@ -1,0 +1,37 @@
+namespace Vido.Core.Plugin;
+
+/// <summary>
+/// Handles downloading, extracting, validating, and removing plugins.
+/// </summary>
+public interface IPluginInstaller
+{
+    /// <summary>
+    /// Installs a plugin by downloading from the given URL and extracting
+    /// to the default plugin directory.
+    /// </summary>
+    /// <param name="entry">The registry entry to install.</param>
+    /// <returns>True if the installation succeeded; false otherwise.</returns>
+    Task<bool> InstallAsync(PluginRegistryEntry entry);
+
+    /// <summary>
+    /// Uninstalls a plugin. Attempts to delete the plugin directory.
+    /// If files are locked, creates a <c>.uninstall</c> marker for cleanup on next restart.
+    /// </summary>
+    /// <param name="pluginId">The plugin ID to uninstall.</param>
+    /// <returns>True if fully removed; false if marked for deferred removal.</returns>
+    Task<bool> UninstallAsync(string pluginId);
+
+    /// <summary>
+    /// Cleans up any plugins marked with <c>.uninstall</c> markers from a previous session.
+    /// Should be called early during application startup.
+    /// </summary>
+    void CleanupPendingUninstalls();
+
+    /// <summary>
+    /// Fetches all plugin entries from the given registry URL.
+    /// Supports <c>https://</c> and <c>file://</c> URLs.
+    /// </summary>
+    /// <param name="registryUrl">The registry URL to fetch from.</param>
+    /// <returns>The parsed registry, or null if fetching/parsing failed.</returns>
+    Task<PluginRegistry?> FetchRegistryAsync(string registryUrl);
+}

--- a/src/Vido.Core/Plugin/PluginPaths.cs
+++ b/src/Vido.Core/Plugin/PluginPaths.cs
@@ -1,0 +1,19 @@
+namespace Vido.Core.Plugin;
+
+/// <summary>
+/// Shared plugin directory path constants.
+/// </summary>
+public static class PluginPaths
+{
+    /// <summary>
+    /// Default plugin installation directory: <c>%APPDATA%/Vido/plugins/</c>.
+    /// </summary>
+    public static string DefaultPluginDirectory
+    {
+        get
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(appData, "Vido", "plugins");
+        }
+    }
+}

--- a/src/Vido.Core/Plugin/PluginRegistryEntry.cs
+++ b/src/Vido.Core/Plugin/PluginRegistryEntry.cs
@@ -1,0 +1,87 @@
+using System.Text.Json.Serialization;
+
+namespace Vido.Core.Plugin;
+
+/// <summary>
+/// Represents a plugin entry from a remote or local plugin registry.
+/// </summary>
+public sealed class PluginRegistryEntry
+{
+    /// <summary>Unique plugin identifier (must match the plugin manifest id).</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>User-facing display name.</summary>
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Short description.</summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Plugin author / publisher name.</summary>
+    [JsonPropertyName("author")]
+    public string Author { get; set; } = string.Empty;
+
+    /// <summary>Current version available in the registry (semver).</summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>License identifier.</summary>
+    [JsonPropertyName("license")]
+    public string License { get; set; } = string.Empty;
+
+    /// <summary>Tags for search / categorization.</summary>
+    [JsonPropertyName("tags")]
+    public List<string> Tags { get; set; } = [];
+
+    /// <summary>URL to download the plugin zip archive.</summary>
+    [JsonPropertyName("downloadUrl")]
+    public string DownloadUrl { get; set; } = string.Empty;
+
+    /// <summary>URL to the plugin icon image.</summary>
+    [JsonPropertyName("iconUrl")]
+    public string? IconUrl { get; set; }
+
+    /// <summary>Repository URL.</summary>
+    [JsonPropertyName("repository")]
+    public string? Repository { get; set; }
+
+    /// <summary>ISO 8601 date string for last update.</summary>
+    [JsonPropertyName("lastUpdated")]
+    public string? LastUpdated { get; set; }
+
+    /// <summary>
+    /// The registry URL this entry was fetched from.
+    /// Set at runtime during registry loading — not serialized from registry JSON.
+    /// </summary>
+    [JsonIgnore]
+    public string RegistryUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Display name of the registry this entry came from.
+    /// Set at runtime during registry loading — not serialized from registry JSON.
+    /// </summary>
+    [JsonIgnore]
+    public string RegistryName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether this entry is from the official Vido plugin registry.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsOfficial { get; set; }
+}
+
+/// <summary>
+/// Represents the JSON structure of a plugin registry file.
+/// </summary>
+public sealed class PluginRegistry
+{
+    /// <summary>Display name for this registry.</summary>
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>List of available plugins.</summary>
+    [JsonPropertyName("plugins")]
+    public List<PluginRegistryEntry> Plugins { get; set; } = [];
+}

--- a/src/Vido.Core/Settings/AppSettings.cs
+++ b/src/Vido.Core/Settings/AppSettings.cs
@@ -28,6 +28,12 @@ public sealed class AppSettings
 
     // --- Plugins ---
 
+    /// <summary>Whether the Installed section in the Plugin Manager is expanded.</summary>
+    public bool PluginInstalledSectionExpanded { get; set; } = true;
+
+    /// <summary>Whether the Available section in the Plugin Manager is expanded.</summary>
+    public bool PluginAvailableSectionExpanded { get; set; } = true;
+
     /// <summary>Additional directories to scan for plugins (besides %APPDATA%/Vido/plugins/).</summary>
     public List<string> PluginDirectories { get; set; } = [];
 
@@ -64,6 +70,8 @@ public sealed class AppSettings
         RightPanelCollapsed = false;
         RightPanelWidth = 300;
         ShowHiddenFiles = false;
+        PluginInstalledSectionExpanded = true;
+        PluginAvailableSectionExpanded = true;
         PluginDirectories = [];
         DisabledPluginIds = [];
         PluginRegistryUrls = [OfficialRegistryUrl];

--- a/src/Vido.PluginHost/PluginHost.cs
+++ b/src/Vido.PluginHost/PluginHost.cs
@@ -25,6 +25,7 @@ public sealed class PluginHost : IPluginHost
 
     private readonly List<PluginInfo> _plugins = [];
     private readonly Dictionary<string, PluginContext> _contexts = [];
+    private readonly Dictionary<string, PluginSettingsStore> _settingsStores = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>List of directories to scan for plugins.</summary>
     private readonly List<string> _scanDirectories = [];
@@ -33,14 +34,7 @@ public sealed class PluginHost : IPluginHost
     /// Default plugin directory: <c>%APPDATA%/Vido/plugins/</c>.
     /// Always scanned regardless of custom directories.
     /// </summary>
-    public static string DefaultPluginDirectory
-    {
-        get
-        {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            return Path.Combine(appData, "Vido", "plugins");
-        }
-    }
+    public static string DefaultPluginDirectory => PluginPaths.DefaultPluginDirectory;
 
     public IReadOnlyList<PluginInfo> Plugins => _plugins.AsReadOnly();
 
@@ -293,6 +287,7 @@ public sealed class PluginHost : IPluginHost
         try
         {
             var settingsStore = new PluginSettingsStore(info.Manifest.Id);
+            _settingsStores[info.Manifest.Id] = settingsStore;
 
             // Apply forceOverride settings — developer-specified values that always win
             ApplyForceOverrides(info.Manifest, settingsStore);
@@ -350,6 +345,22 @@ public sealed class PluginHost : IPluginHost
 
         info.State = PluginState.Deactivated;
         _logService.Info($"Plugin '{info.Manifest.Id}' deactivated", "PluginHost");
+    }
+
+    // ── Settings Store Access ──
+
+    /// <inheritdoc/>
+    public IPluginSettingsStore GetSettingsStore(string pluginId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pluginId);
+
+        if (_settingsStores.TryGetValue(pluginId, out var existing))
+            return existing;
+
+        // Create a new store for plugins that are installed but not yet activated
+        var store = new PluginSettingsStore(pluginId);
+        _settingsStores[pluginId] = store;
+        return store;
     }
 
     // ── Force Override ──

--- a/src/Vido.Services/Plugin/PluginInstaller.cs
+++ b/src/Vido.Services/Plugin/PluginInstaller.cs
@@ -1,0 +1,245 @@
+using System.IO.Compression;
+using System.Net.Http;
+using System.Text.Json;
+using Vido.Core.Logging;
+using Vido.Core.Plugin;
+
+namespace Vido.Services.Plugin;
+
+/// <summary>
+/// Handles downloading, extracting, validating, and removing plugins.
+/// Supports both HTTPS and file:// registry URLs.
+/// </summary>
+public sealed class PluginInstaller : IPluginInstaller
+{
+    private readonly ILogService _logService;
+    private readonly HttpClient _httpClient;
+    private readonly string _pluginDirectory;
+
+    /// <summary>Marker file placed in a plugin directory to flag deferred deletion.</summary>
+    private const string UninstallMarker = ".uninstall";
+
+    public PluginInstaller(ILogService logService)
+        : this(logService, new HttpClient(), PluginPaths.DefaultPluginDirectory)
+    {
+    }
+
+    /// <summary>
+    /// Internal constructor for testing — allows injecting custom HttpClient and directory.
+    /// </summary>
+    internal PluginInstaller(ILogService logService, HttpClient httpClient, string pluginDirectory)
+    {
+        _logService = logService;
+        _httpClient = httpClient;
+        _pluginDirectory = pluginDirectory;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> InstallAsync(PluginRegistryEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        if (string.IsNullOrWhiteSpace(entry.Id))
+            throw new ArgumentException("Plugin entry must have an ID.", nameof(entry));
+        if (string.IsNullOrWhiteSpace(entry.DownloadUrl))
+            throw new ArgumentException("Plugin entry must have a download URL.", nameof(entry));
+
+        var targetDir = Path.Combine(_pluginDirectory, entry.Id);
+
+        try
+        {
+            _logService.Info($"Installing plugin '{entry.Id}' from {entry.DownloadUrl}...", "PluginInstaller");
+
+            // Download the zip
+            byte[] zipData;
+            if (entry.DownloadUrl.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+            {
+                var localPath = new Uri(entry.DownloadUrl).LocalPath;
+                zipData = await File.ReadAllBytesAsync(localPath);
+            }
+            else
+            {
+                zipData = await _httpClient.GetByteArrayAsync(entry.DownloadUrl);
+            }
+
+            // Ensure target directory exists and is clean
+            if (Directory.Exists(targetDir))
+                Directory.Delete(targetDir, recursive: true);
+            Directory.CreateDirectory(targetDir);
+
+            // Extract
+            using var zipStream = new MemoryStream(zipData);
+            ZipFile.ExtractToDirectory(zipStream, targetDir, overwriteFiles: true);
+
+            // Validate that plugin.json exists in the extracted content
+            var manifestPath = Path.Combine(targetDir, "plugin.json");
+            if (!File.Exists(manifestPath))
+            {
+                // Check if the zip had a single root folder
+                var subDirs = Directory.GetDirectories(targetDir);
+                if (subDirs.Length == 1)
+                {
+                    var innerManifest = Path.Combine(subDirs[0], "plugin.json");
+                    if (File.Exists(innerManifest))
+                    {
+                        // Move contents up one level
+                        MoveContentsUp(subDirs[0], targetDir);
+                        manifestPath = Path.Combine(targetDir, "plugin.json");
+                    }
+                }
+            }
+
+            if (!File.Exists(manifestPath))
+            {
+                _logService.Error($"Plugin '{entry.Id}' installation failed: plugin.json not found in archive.", "PluginInstaller");
+                Directory.Delete(targetDir, recursive: true);
+                return false;
+            }
+
+            // Remove any stale uninstall markers
+            var markerPath = Path.Combine(targetDir, UninstallMarker);
+            if (File.Exists(markerPath))
+                File.Delete(markerPath);
+
+            _logService.Info($"Plugin '{entry.Id}' installed successfully.", "PluginInstaller");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logService.Error($"Plugin '{entry.Id}' installation failed: {ex.Message}", "PluginInstaller");
+
+            // Clean up partial install
+            try
+            {
+                if (Directory.Exists(targetDir))
+                    Directory.Delete(targetDir, recursive: true);
+            }
+            catch { /* best effort */ }
+
+            return false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> UninstallAsync(string pluginId)
+    {
+        if (string.IsNullOrWhiteSpace(pluginId))
+            throw new ArgumentException("Plugin ID must not be empty.", nameof(pluginId));
+
+        var targetDir = Path.Combine(_pluginDirectory, pluginId);
+
+        if (!Directory.Exists(targetDir))
+        {
+            _logService.Warning($"Plugin '{pluginId}' directory not found — nothing to uninstall.", "PluginInstaller");
+            return Task.FromResult(true);
+        }
+
+        try
+        {
+            Directory.Delete(targetDir, recursive: true);
+            _logService.Info($"Plugin '{pluginId}' uninstalled successfully.", "PluginInstaller");
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            // DLL locking likely — create marker for deferred cleanup
+            _logService.Warning(
+                $"Plugin '{pluginId}' files are locked — marking for removal on next restart: {ex.Message}",
+                "PluginInstaller");
+
+            try
+            {
+                var markerPath = Path.Combine(targetDir, UninstallMarker);
+                File.WriteAllText(markerPath, DateTime.UtcNow.ToString("O"));
+            }
+            catch (Exception markerEx)
+            {
+                _logService.Error($"Failed to create uninstall marker for '{pluginId}': {markerEx.Message}", "PluginInstaller");
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void CleanupPendingUninstalls()
+    {
+        if (!Directory.Exists(_pluginDirectory))
+            return;
+
+        foreach (var dir in Directory.GetDirectories(_pluginDirectory))
+        {
+            var markerPath = Path.Combine(dir, UninstallMarker);
+            if (!File.Exists(markerPath)) continue;
+
+            var pluginId = Path.GetFileName(dir);
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+                _logService.Info($"Cleaned up deferred uninstall for '{pluginId}'.", "PluginInstaller");
+            }
+            catch (Exception ex)
+            {
+                _logService.Warning($"Still unable to remove '{pluginId}': {ex.Message}", "PluginInstaller");
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<PluginRegistry?> FetchRegistryAsync(string registryUrl)
+    {
+        if (string.IsNullOrWhiteSpace(registryUrl))
+            return null;
+
+        try
+        {
+            string json;
+            if (registryUrl.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
+            {
+                var localPath = new Uri(registryUrl).LocalPath;
+                json = await File.ReadAllTextAsync(localPath);
+            }
+            else
+            {
+                // Ensure URL ends with registry.json if it doesn't have a file extension
+                var fetchUrl = registryUrl;
+                if (!fetchUrl.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                {
+                    fetchUrl = fetchUrl.TrimEnd('/') + "/registry.json";
+                }
+                json = await _httpClient.GetStringAsync(fetchUrl);
+            }
+
+            var registry = JsonSerializer.Deserialize<PluginRegistry>(json);
+            return registry;
+        }
+        catch (Exception ex)
+        {
+            _logService.Warning($"Failed to fetch registry from '{registryUrl}': {ex.Message}", "PluginInstaller");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Moves all files and directories from <paramref name="sourceDir"/> into
+    /// <paramref name="targetDir"/>, then removes <paramref name="sourceDir"/>.
+    /// Used when a zip has a single root folder wrapping the plugin files.
+    /// </summary>
+    private static void MoveContentsUp(string sourceDir, string targetDir)
+    {
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            var destFile = Path.Combine(targetDir, Path.GetFileName(file));
+            File.Move(file, destFile, overwrite: true);
+        }
+
+        foreach (var dir in Directory.GetDirectories(sourceDir))
+        {
+            var destDir = Path.Combine(targetDir, Path.GetFileName(dir));
+            if (Directory.Exists(destDir))
+                Directory.Delete(destDir, recursive: true);
+            Directory.Move(dir, destDir);
+        }
+
+        Directory.Delete(sourceDir, recursive: false);
+    }
+}

--- a/src/Vido.ViewModels/PluginItemViewModel.cs
+++ b/src/Vido.ViewModels/PluginItemViewModel.cs
@@ -1,0 +1,206 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Vido.Core.Plugin;
+
+namespace Vido.ViewModels;
+
+/// <summary>
+/// Represents a single plugin in the Plugin Manager sidebar.
+/// Tracks installed/available state, enabled/disabled state, and provides
+/// command targets for install/uninstall/enable/disable actions.
+/// </summary>
+public partial class PluginItemViewModel : ObservableObject
+{
+    /// <summary>Unique plugin identifier.</summary>
+    public string Id { get; }
+
+    /// <summary>Display name of the plugin.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Short description of the plugin.</summary>
+    public string Description { get; }
+
+    /// <summary>Publisher / author name.</summary>
+    public string Publisher { get; }
+
+    /// <summary>Plugin version string.</summary>
+    public string Version { get; }
+
+    /// <summary>License identifier.</summary>
+    public string License { get; }
+
+    /// <summary>Tags for search.</summary>
+    public IReadOnlyList<string> Tags { get; }
+
+    /// <summary>Icon URL (may be null).</summary>
+    public string? IconUrl { get; }
+
+    /// <summary>Download URL for installation.</summary>
+    public string DownloadUrl { get; }
+
+    /// <summary>Repository URL.</summary>
+    public string? Repository { get; }
+
+    /// <summary>Last updated date string.</summary>
+    public string? LastUpdated { get; }
+
+    /// <summary>Which registry this plugin came from.</summary>
+    public string RegistryName { get; }
+
+    /// <summary>The registry URL this plugin came from.</summary>
+    public string RegistryUrl { get; }
+
+    /// <summary>Whether this plugin is from the official Vido registry (shows verified badge).</summary>
+    [ObservableProperty]
+    private bool _isOfficial;
+
+    /// <summary>Whether the plugin is currently installed locally.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    [NotifyPropertyChangedFor(nameof(ShowInstallButton))]
+    [NotifyPropertyChangedFor(nameof(ShowUninstallButton))]
+    [NotifyPropertyChangedFor(nameof(ShowSettingsCog))]
+    [NotifyPropertyChangedFor(nameof(ShowEnableDisableToggle))]
+    private bool _isInstalled;
+
+    /// <summary>Whether the plugin is enabled (only relevant when installed).</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    private bool _isEnabled = true;
+
+    /// <summary>Whether an install/uninstall operation is in progress.</summary>
+    [ObservableProperty]
+    private bool _isBusy;
+
+    /// <summary>Status text: "Enabled", "Disabled", or empty for available plugins.</summary>
+    public string StatusText => IsInstalled ? (IsEnabled ? "Enabled" : "Disabled") : string.Empty;
+
+    /// <summary>Show the Install button (available plugins only).</summary>
+    public bool ShowInstallButton => !IsInstalled;
+
+    /// <summary>Show the Uninstall button (installed plugins only).</summary>
+    public bool ShowUninstallButton => IsInstalled;
+
+    /// <summary>Show the settings cog (installed plugins only).</summary>
+    public bool ShowSettingsCog => IsInstalled;
+
+    /// <summary>Show the enable/disable toggle (installed plugins only).</summary>
+    public bool ShowEnableDisableToggle => IsInstalled;
+
+    /// <summary>The PluginInfo from the host (set when installed, null when only in registry).</summary>
+    public PluginInfo? PluginInfo { get; set; }
+
+    /// <summary>The registry entry (set when the plugin is known in a registry).</summary>
+    public PluginRegistryEntry? RegistryEntry { get; set; }
+
+    /// <summary>
+    /// Creates a PluginItemViewModel from a registry entry (available plugin).
+    /// </summary>
+    public static PluginItemViewModel FromRegistryEntry(PluginRegistryEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        return new PluginItemViewModel(
+            id: entry.Id,
+            displayName: entry.DisplayName,
+            description: entry.Description,
+            publisher: entry.Author,
+            version: entry.Version,
+            license: entry.License,
+            tags: entry.Tags,
+            iconUrl: entry.IconUrl,
+            downloadUrl: entry.DownloadUrl,
+            repository: entry.Repository,
+            lastUpdated: entry.LastUpdated,
+            registryName: entry.RegistryName,
+            registryUrl: entry.RegistryUrl,
+            isOfficial: entry.IsOfficial,
+            isInstalled: false)
+        {
+            RegistryEntry = entry
+        };
+    }
+
+    /// <summary>
+    /// Creates a PluginItemViewModel from an installed PluginInfo.
+    /// </summary>
+    public static PluginItemViewModel FromPluginInfo(PluginInfo info, PluginRegistryEntry? registryEntry = null)
+    {
+        ArgumentNullException.ThrowIfNull(info);
+        var manifest = info.Manifest;
+        var vm = new PluginItemViewModel(
+            id: manifest.Id,
+            displayName: manifest.DisplayName,
+            description: manifest.Description,
+            publisher: manifest.Author,
+            version: manifest.Version,
+            license: manifest.License,
+            tags: manifest.Tags,
+            iconUrl: registryEntry?.IconUrl,
+            downloadUrl: registryEntry?.DownloadUrl ?? string.Empty,
+            repository: manifest.Repository,
+            lastUpdated: registryEntry?.LastUpdated,
+            registryName: registryEntry?.RegistryName ?? string.Empty,
+            registryUrl: registryEntry?.RegistryUrl ?? string.Empty,
+            isOfficial: registryEntry?.IsOfficial ?? false,
+            isInstalled: true)
+        {
+            PluginInfo = info,
+            RegistryEntry = registryEntry,
+            IsEnabled = info.State != PluginState.Disabled && info.State != PluginState.Error,
+        };
+
+        return vm;
+    }
+
+    private PluginItemViewModel(
+        string id,
+        string displayName,
+        string description,
+        string publisher,
+        string version,
+        string license,
+        IReadOnlyList<string> tags,
+        string? iconUrl,
+        string downloadUrl,
+        string? repository,
+        string? lastUpdated,
+        string registryName,
+        string registryUrl,
+        bool isOfficial,
+        bool isInstalled)
+    {
+        Id = id;
+        DisplayName = string.IsNullOrWhiteSpace(displayName) ? id : displayName;
+        Description = description;
+        Publisher = publisher;
+        Version = version;
+        License = license;
+        Tags = tags;
+        IconUrl = iconUrl;
+        DownloadUrl = downloadUrl;
+        Repository = repository;
+        LastUpdated = lastUpdated;
+        RegistryName = registryName;
+        RegistryUrl = registryUrl;
+        _isOfficial = isOfficial;
+        _isInstalled = isInstalled;
+    }
+
+    /// <summary>
+    /// Returns true if this item matches the given search query (title or tags).
+    /// </summary>
+    public bool MatchesSearch(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return true;
+
+        if (DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        foreach (var tag in Tags)
+        {
+            if (tag.Contains(query, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Vido.ViewModels/PluginManagerViewModel.cs
+++ b/src/Vido.ViewModels/PluginManagerViewModel.cs
@@ -1,0 +1,329 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Vido.Core.Logging;
+using Vido.Core.Plugin;
+using Vido.Core.Settings;
+
+namespace Vido.ViewModels;
+
+/// <summary>
+/// ViewModel for the Plugin Manager sidebar panel.
+/// Manages registry fetching, search/filter, install/uninstall, and plugin state.
+/// </summary>
+public partial class PluginManagerViewModel : ObservableObject
+{
+    private readonly IPluginHost _pluginHost;
+    private readonly IPluginInstaller _pluginInstaller;
+    private readonly ISettingsService _settingsService;
+    private readonly ILogService _logService;
+
+    /// <summary>All plugin items (both installed and available).</summary>
+    private readonly List<PluginItemViewModel> _allPlugins = [];
+
+    /// <summary>Map of registry URL → display name for the dropdown.</summary>
+    private readonly Dictionary<string, string> _registryNames = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Installed plugins filtered by search and registry.</summary>
+    public ObservableCollection<PluginItemViewModel> InstalledPlugins { get; } = [];
+
+    /// <summary>Available plugins filtered by search and registry.</summary>
+    public ObservableCollection<PluginItemViewModel> AvailablePlugins { get; } = [];
+
+    /// <summary>Registry source options for the dropdown.</summary>
+    public ObservableCollection<string> RegistrySources { get; } = ["All"];
+
+    /// <summary>Search query for filtering.</summary>
+    [ObservableProperty]
+    private string _searchQuery = string.Empty;
+
+    partial void OnSearchQueryChanged(string value) => ApplyFilter();
+
+    /// <summary>Selected registry source.</summary>
+    [ObservableProperty]
+    private string _selectedRegistrySource = "All";
+
+    partial void OnSelectedRegistrySourceChanged(string value) => ApplyFilter();
+
+    /// <summary>Whether the registry is loading.</summary>
+    [ObservableProperty]
+    private bool _isLoading;
+
+    /// <summary>Count of installed plugins (for badge).</summary>
+    [ObservableProperty]
+    private int _installedCount;
+
+    /// <summary>Count of available plugins (for badge).</summary>
+    [ObservableProperty]
+    private int _availableCount;
+
+    /// <summary>Whether the installed section is expanded.</summary>
+    [ObservableProperty]
+    private bool _isInstalledExpanded = true;
+
+    /// <summary>Whether the available section is expanded.</summary>
+    [ObservableProperty]
+    private bool _isAvailableExpanded = true;
+
+    /// <summary>
+    /// Fired when a plugin item's detail should be opened in the main tab area.
+    /// The string parameter is the plugin ID.
+    /// </summary>
+    public event Action<PluginItemViewModel>? OpenDetailRequested;
+
+    /// <summary>
+    /// Fired when a plugin item's settings should be opened.
+    /// The string parameter is the plugin ID.
+    /// </summary>
+    public event Action<PluginItemViewModel>? OpenSettingsRequested;
+
+    public PluginManagerViewModel(
+        IPluginHost pluginHost,
+        IPluginInstaller pluginInstaller,
+        ISettingsService settingsService,
+        ILogService logService)
+    {
+        _pluginHost = pluginHost;
+        _pluginInstaller = pluginInstaller;
+        _settingsService = settingsService;
+        _logService = logService;
+
+        // Restore collapsed/expanded state from persisted settings
+        var s = _settingsService.Current;
+        _isInstalledExpanded = s.PluginInstalledSectionExpanded;
+        _isAvailableExpanded = s.PluginAvailableSectionExpanded;
+    }
+
+    partial void OnIsInstalledExpandedChanged(bool value)
+    {
+        _settingsService.Current.PluginInstalledSectionExpanded = value;
+        _settingsService.QueueSave();
+    }
+
+    partial void OnIsAvailableExpandedChanged(bool value)
+    {
+        _settingsService.Current.PluginAvailableSectionExpanded = value;
+        _settingsService.QueueSave();
+    }
+
+    /// <summary>
+    /// Loads installed plugins from the plugin host and fetches registry data.
+    /// Call this when the panel becomes visible.
+    /// </summary>
+    [RelayCommand]
+    public async Task LoadAsync()
+    {
+        if (IsLoading) return;
+        IsLoading = true;
+
+        try
+        {
+            _allPlugins.Clear();
+            _registryNames.Clear();
+            RegistrySources.Clear();
+            RegistrySources.Add("All");
+
+            // 1. Load installed plugins from the host
+            var installedMap = new Dictionary<string, PluginItemViewModel>(StringComparer.OrdinalIgnoreCase);
+            foreach (var info in _pluginHost.Plugins)
+            {
+                var item = PluginItemViewModel.FromPluginInfo(info);
+                installedMap[info.Manifest.Id] = item;
+                _allPlugins.Add(item);
+            }
+
+            // 2. Fetch registries
+            var registryUrls = _settingsService.Current.PluginRegistryUrls;
+            var seenIds = new HashSet<string>(installedMap.Keys, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var url in registryUrls)
+            {
+                var registry = await _pluginInstaller.FetchRegistryAsync(url);
+                if (registry is null) continue;
+
+                var registryName = !string.IsNullOrWhiteSpace(registry.Name)
+                    ? registry.Name
+                    : new Uri(url).Host;
+
+                _registryNames[url] = registryName;
+
+                if (!RegistrySources.Contains(registryName))
+                    RegistrySources.Add(registryName);
+
+                var isOfficial = url.Equals(AppSettings.OfficialRegistryUrl, StringComparison.OrdinalIgnoreCase);
+
+                foreach (var entry in registry.Plugins)
+                {
+                    entry.RegistryUrl = url;
+                    entry.RegistryName = registryName;
+                    entry.IsOfficial = isOfficial;
+
+                    if (installedMap.TryGetValue(entry.Id, out var installed))
+                    {
+                        // Update installed plugin with registry info
+                        installed.RegistryEntry = entry;
+                        installed.IsOfficial = isOfficial;
+                    }
+                    else if (seenIds.Add(entry.Id))
+                    {
+                        // New available plugin (first registry wins for dedup)
+                        var item = PluginItemViewModel.FromRegistryEntry(entry);
+                        _allPlugins.Add(item);
+                    }
+                }
+            }
+
+            ApplyFilter();
+        }
+        catch (Exception ex)
+        {
+            _logService.Error($"Failed to load plugin manager: {ex.Message}", "PluginManager");
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    /// <summary>
+    /// Installs a plugin and updates the lists.
+    /// </summary>
+    [RelayCommand]
+    public async Task InstallPluginAsync(PluginItemViewModel item)
+    {
+        if (item.IsInstalled || item.IsBusy || item.RegistryEntry is null) return;
+
+        item.IsBusy = true;
+        try
+        {
+            var success = await _pluginInstaller.InstallAsync(item.RegistryEntry);
+            if (success)
+            {
+                item.IsInstalled = true;
+                item.IsEnabled = true;
+
+                // Try to activate the plugin immediately
+                try
+                {
+                    _pluginHost.ActivateAll(); // Will pick up the newly installed plugin
+                    var info = _pluginHost.GetPlugin(item.Id);
+                    if (info is not null)
+                        item.PluginInfo = info;
+                }
+                catch (Exception ex)
+                {
+                    _logService.Warning($"Plugin '{item.Id}' installed but could not be activated: {ex.Message}", "PluginManager");
+                }
+
+                ApplyFilter();
+                OpenDetailRequested?.Invoke(item);
+                _logService.Info($"Plugin '{item.DisplayName}' installed successfully.", "PluginManager");
+            }
+        }
+        finally
+        {
+            item.IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Uninstalls a plugin and updates the lists.
+    /// </summary>
+    [RelayCommand]
+    public async Task UninstallPluginAsync(PluginItemViewModel item)
+    {
+        if (!item.IsInstalled || item.IsBusy) return;
+
+        item.IsBusy = true;
+        try
+        {
+            // Deactivate the plugin first
+            _pluginHost.SetEnabled(item.Id, false);
+
+            var fullyRemoved = await _pluginInstaller.UninstallAsync(item.Id);
+
+            item.IsInstalled = false;
+            item.IsEnabled = false;
+            item.PluginInfo = null;
+
+            ApplyFilter();
+
+            var msg = fullyRemoved
+                ? $"Plugin '{item.DisplayName}' uninstalled."
+                : $"Plugin '{item.DisplayName}' marked for removal on next restart.";
+            _logService.Info(msg, "PluginManager");
+        }
+        finally
+        {
+            item.IsBusy = false;
+        }
+    }
+
+    /// <summary>
+    /// Toggles a plugin's enabled/disabled state.
+    /// </summary>
+    [RelayCommand]
+    public void ToggleEnabled(PluginItemViewModel item)
+    {
+        if (!item.IsInstalled) return;
+
+        var newState = !item.IsEnabled;
+        _pluginHost.SetEnabled(item.Id, newState);
+        item.IsEnabled = newState;
+
+        _logService.Info($"Plugin '{item.DisplayName}' {(newState ? "enabled" : "disabled")}.", "PluginManager");
+    }
+
+    /// <summary>
+    /// Opens the detail panel for a plugin.
+    /// </summary>
+    [RelayCommand]
+    public void OpenDetail(PluginItemViewModel item)
+    {
+        OpenDetailRequested?.Invoke(item);
+    }
+
+    /// <summary>
+    /// Opens the settings for a plugin.
+    /// </summary>
+    [RelayCommand]
+    public void OpenPluginSettings(PluginItemViewModel item)
+    {
+        OpenSettingsRequested?.Invoke(item);
+    }
+
+    /// <summary>
+    /// Applies search and registry filters to the plugin lists.
+    /// </summary>
+    private void ApplyFilter()
+    {
+        InstalledPlugins.Clear();
+        AvailablePlugins.Clear();
+
+        foreach (var item in _allPlugins)
+        {
+            // Search filter
+            if (!item.MatchesSearch(SearchQuery))
+                continue;
+
+            // Registry filter
+            if (SelectedRegistrySource != "All")
+            {
+                if (!string.Equals(item.RegistryName, SelectedRegistrySource, StringComparison.OrdinalIgnoreCase))
+                {
+                    // For installed plugins without a registry match, always show them
+                    if (!item.IsInstalled)
+                        continue;
+                }
+            }
+
+            if (item.IsInstalled)
+                InstalledPlugins.Add(item);
+            else
+                AvailablePlugins.Add(item);
+        }
+
+        InstalledCount = InstalledPlugins.Count;
+        AvailableCount = AvailablePlugins.Count;
+    }
+}

--- a/src/Vido.ViewModels/SettingDisplayItem.cs
+++ b/src/Vido.ViewModels/SettingDisplayItem.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Vido.Core.Plugin;
+
+namespace Vido.ViewModels;
+
+/// <summary>
+/// Represents a single setting for display in the Plugin Detail Settings tab.
+/// Binds to the appropriate control based on <see cref="SettingType"/> and
+/// persists changes immediately to the <see cref="IPluginSettingsStore"/>.
+/// </summary>
+public partial class SettingDisplayItem : ObservableObject
+{
+    private readonly IPluginSettingsStore _store;
+    private readonly SettingContribution _definition;
+    private bool _suppressSave;
+
+    /// <summary>Setting unique identifier.</summary>
+    public string Id => _definition.Id;
+
+    /// <summary>Display title.</summary>
+    public string Title => _definition.Title;
+
+    /// <summary>Description text shown below the control.</summary>
+    public string Description => _definition.Description;
+
+    /// <summary>Setting type: boolean, string, number, enum.</summary>
+    public string SettingType => _definition.Type;
+
+    /// <summary>Section name for grouping (may be null).</summary>
+    public string? Section => _definition.Section;
+
+    /// <summary>Enum values (only for enum type).</summary>
+    public IReadOnlyList<string> EnumValues => _definition.EnumValues;
+
+    /// <summary>Whether this is a boolean setting.</summary>
+    public bool IsBoolean => SettingType.Equals("boolean", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether this is a string setting.</summary>
+    public bool IsString => SettingType.Equals("string", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether this is a number setting.</summary>
+    public bool IsNumber => SettingType.Equals("number", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Whether this is an enum setting.</summary>
+    public bool IsEnum => SettingType.Equals("enum", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Boolean value options for the ComboBox.</summary>
+    public static IReadOnlyList<string> BooleanOptions { get; } = ["True", "False"];
+
+    /// <summary>The string value of the setting (used for string/number TextBox binding).</summary>
+    [ObservableProperty]
+    private string _stringValue = string.Empty;
+
+    partial void OnStringValueChanged(string value)
+    {
+        if (_suppressSave) return;
+        if (IsNumber)
+        {
+            if (double.TryParse(value, out var num))
+                _store.Set(Id, num);
+        }
+        else if (IsString)
+        {
+            _store.Set(Id, value);
+        }
+    }
+
+    /// <summary>The selected boolean string ("True"/"False") for boolean ComboBox binding.</summary>
+    [ObservableProperty]
+    private string _selectedBooleanValue = "False";
+
+    partial void OnSelectedBooleanValueChanged(string value)
+    {
+        if (_suppressSave) return;
+        _store.Set(Id, value.Equals("True", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>The selected enum value for enum ComboBox binding.</summary>
+    [ObservableProperty]
+    private string _selectedEnumValue = string.Empty;
+
+    partial void OnSelectedEnumValueChanged(string value)
+    {
+        if (_suppressSave) return;
+        if (!string.IsNullOrEmpty(value))
+            _store.Set(Id, value);
+    }
+
+    public SettingDisplayItem(SettingContribution definition, IPluginSettingsStore store)
+    {
+        _definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+
+        _suppressSave = true;
+        LoadCurrentValue();
+        _suppressSave = false;
+    }
+
+    /// <summary>
+    /// Loads the current value from the store (or falls back to default).
+    /// </summary>
+    private void LoadCurrentValue()
+    {
+        if (IsBoolean)
+        {
+            var defaultVal = ConvertDefault(_definition.Default) is true;
+            var val = _store.Get(Id, defaultVal);
+            SelectedBooleanValue = val ? "True" : "False";
+        }
+        else if (IsString)
+        {
+            var defaultVal = ConvertDefault(_definition.Default)?.ToString() ?? string.Empty;
+            StringValue = _store.Get(Id, defaultVal);
+        }
+        else if (IsNumber)
+        {
+            var defaultNum = ConvertDefault(_definition.Default) is double d ? d : 0.0;
+            try
+            {
+                var val = _store.Get(Id, defaultNum);
+                StringValue = val.ToString();
+            }
+            catch
+            {
+                StringValue = defaultNum.ToString();
+            }
+        }
+        else if (IsEnum)
+        {
+            var defaultVal = ConvertDefault(_definition.Default)?.ToString()
+                ?? _definition.EnumValues.FirstOrDefault() ?? string.Empty;
+            var val = _store.Get(Id, defaultVal);
+            SelectedEnumValue = val;
+        }
+    }
+
+    /// <summary>
+    /// Converts a default value from the manifest (which may be a JsonElement) to the appropriate type.
+    /// </summary>
+    private static object? ConvertDefault(object? value)
+    {
+        if (value is JsonElement je)
+        {
+            return je.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Number => je.GetDouble(),
+                JsonValueKind.String => je.GetString(),
+                _ => null
+            };
+        }
+        return value;
+    }
+}

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -43,11 +43,15 @@ public partial class MainWindow : Window
     private readonly StatusBarViewModel _statusBarViewModel;
     private readonly IKeyboardShortcutService _keyboardShortcutService;
     private readonly IContributionRegistry _contributionRegistry;
+    private readonly IPluginInstaller _pluginInstaller;
+    private readonly IPluginHost _pluginHost;
 
     private TitleBarViewModel? _titleBarViewModel;
     private ActivityBarViewModel? _activityBarViewModel;
     private SidebarViewModel? _sidebarViewModel;
     private FileExplorerPanel? _fileExplorerPanel;
+    private PluginManagerPanel? _pluginManagerPanel;
+    private PluginManagerViewModel? _pluginManagerViewModel;
 
     // Remembered panel dimensions for toggle persistence
     private double _bottomPanelHeight = 200;
@@ -83,6 +87,8 @@ public partial class MainWindow : Window
         ILogService logService,
         IKeyboardShortcutService keyboardShortcutService,
         IContributionRegistry contributionRegistry,
+        IPluginInstaller pluginInstaller,
+        IPluginHost pluginHost,
         FileExplorerViewModel fileExplorerViewModel,
         VideoPlayerViewModel videoPlayerViewModel,
         MainWindowViewModel mainWindowViewModel,
@@ -95,12 +101,18 @@ public partial class MainWindow : Window
         _logService = logService;
         _keyboardShortcutService = keyboardShortcutService;
         _contributionRegistry = contributionRegistry;
+        _pluginInstaller = pluginInstaller;
+        _pluginHost = pluginHost;
         _fileExplorerViewModel = fileExplorerViewModel;
         _videoPlayerViewModel = videoPlayerViewModel;
         _mainWindowViewModel = mainWindowViewModel;
         _outputLogViewModel = outputLogViewModel;
         _videoDetailsViewModel = videoDetailsViewModel;
         _statusBarViewModel = statusBarViewModel;
+
+        // Create the Plugin Manager ViewModel
+        _pluginManagerViewModel = new PluginManagerViewModel(
+            pluginHost, pluginInstaller, settingsService, logService);
 
         InitializeComponent();
         SetupWindowChrome();
@@ -999,6 +1011,15 @@ public partial class MainWindow : Window
             DynamicTabContent.Content = new SettingsPage();
             DynamicTabContent.Visibility = Visibility.Visible;
         }
+        else if (activeTab.Id.StartsWith("plugin.detail.", StringComparison.Ordinal))
+        {
+            // Show plugin detail panel
+            VideoPlayer.Visibility = Visibility.Collapsed;
+            var pluginId = activeTab.Id["plugin.detail.".Length..];
+            var panel = GetOrCreatePluginDetailPanel(pluginId);
+            DynamicTabContent.Content = panel;
+            DynamicTabContent.Visibility = Visibility.Visible;
+        }
         else
         {
             // Future tabs — show empty for now
@@ -1006,6 +1027,27 @@ public partial class MainWindow : Window
             DynamicTabContent.Content = null;
             DynamicTabContent.Visibility = Visibility.Visible;
         }
+    }
+
+    /// <summary>
+    /// Gets or creates a PluginDetailPanel for the given plugin ID.
+    /// </summary>
+    private PluginDetailPanel GetOrCreatePluginDetailPanel(string pluginId)
+    {
+        if (_pluginDetailPanels.TryGetValue(pluginId, out var existing))
+            return existing;
+
+        // Find the plugin item from the manager VM
+        PluginItemViewModel? item = null;
+        if (_pluginManagerViewModel is not null)
+        {
+            item = _pluginManagerViewModel.InstalledPlugins.FirstOrDefault(p => p.Id == pluginId)
+                ?? _pluginManagerViewModel.AvailablePlugins.FirstOrDefault(p => p.Id == pluginId);
+        }
+
+        var panel = new PluginDetailPanel(item, _pluginManagerViewModel, _pluginHost, _logService);
+        _pluginDetailPanels[pluginId] = panel;
+        return panel;
     }
 
     // ── Panel visibility ──
@@ -1130,8 +1172,20 @@ public partial class MainWindow : Window
                 case SidebarPanelKind.Explorer:
                     Sidebar.SetPanelContent(_fileExplorerPanel);
                     break;
+                case SidebarPanelKind.Extensions:
+                    if (_pluginManagerPanel is null)
+                    {
+                        _pluginManagerPanel = new PluginManagerPanel
+                        {
+                            DataContext = _pluginManagerViewModel
+                        };
+                        WirePluginManagerEvents();
+                    }
+                    Sidebar.SetPanelContent(_pluginManagerPanel);
+                    // Load plugin data when switching to extensions
+                    _ = _pluginManagerViewModel?.LoadAsync();
+                    break;
                 default:
-                    // Future panels (Extensions, Settings) will be added here
                     Sidebar.SetPanelContent(null);
                     break;
             }
@@ -1187,6 +1241,38 @@ public partial class MainWindow : Window
         Drop += OnWindowDrop;
         DragEnter += OnWindowDragEnter;
         DragOver += OnWindowDragOver;
+    }
+
+    // ── Plugin Manager (Extensions sidebar) wiring ──
+
+    /// <summary>
+    /// Map of plugin ID → detail panel content for reuse (avoids re-creating panels).
+    /// </summary>
+    private readonly Dictionary<string, PluginDetailPanel> _pluginDetailPanels = [];
+
+    /// <summary>
+    /// Wires events from the Plugin Manager ViewModel to open detail panels and settings.
+    /// </summary>
+    private void WirePluginManagerEvents()
+    {
+        if (_pluginManagerViewModel is null) return;
+
+        _pluginManagerViewModel.OpenDetailRequested += item =>
+        {
+            var tabId = $"plugin.detail.{item.Id}";
+            _mainWindowViewModel.OpenTab(tabId, item.DisplayName, isClosable: true);
+            UpdateTabContent();
+        };
+
+        _pluginManagerViewModel.OpenSettingsRequested += item =>
+        {
+            var tabId = $"plugin.detail.{item.Id}";
+            _mainWindowViewModel.OpenTab(tabId, item.DisplayName, isClosable: true);
+            UpdateTabContent();
+            // Scroll to settings tab — the detail panel will handle this
+            if (_pluginDetailPanels.TryGetValue(item.Id, out var panel))
+                panel.SwitchToSettings();
+        };
     }
 
     // ── Plugin contribution wiring ──
@@ -1560,6 +1646,13 @@ public partial class MainWindow : Window
         const int GclpHbrBackground = -10;
         var darkBrush = CreateSolidBrush(0x001F1F1F);
         SetClassLongPtr(hwnd, GclpHbrBackground, darkBrush);
+
+        // Ensure WS_SYSMENU is set so the taskbar shows our Window.Icon.
+        // WindowStyle="None" can strip this flag, causing a blank taskbar icon.
+        const int GWL_STYLE = -16;
+        const int WS_SYSMENU = 0x00080000;
+        var style = GetWindowLongPtr(hwnd, GWL_STYLE);
+        SetWindowLongPtr(hwnd, GWL_STYLE, new IntPtr(style.ToInt64() | WS_SYSMENU));
     }
 
     private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
@@ -1615,6 +1708,12 @@ public partial class MainWindow : Window
 
     [DllImport("user32.dll", EntryPoint = "SetClassLongPtr")]
     private static extern IntPtr SetClassLongPtr(IntPtr hwnd, int index, IntPtr newLong);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+    private static extern IntPtr GetWindowLongPtr(IntPtr hwnd, int index);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+    private static extern IntPtr SetWindowLongPtr(IntPtr hwnd, int index, IntPtr newLong);
 
     [DllImport("user32.dll")]
     private static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint flags);

--- a/src/Vido.Views/Panels/PluginDetailPanel.xaml
+++ b/src/Vido.Views/Panels/PluginDetailPanel.xaml
@@ -1,0 +1,369 @@
+<UserControl x:Class="Vido.Views.Panels.PluginDetailPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Background="{DynamicResource EditorBackgroundBrush}">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/Brushes.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <BooleanToVisibilityConverter x:Key="BoolToVis" />
+
+            <!-- Action button style (blue install/enable) -->
+            <Style x:Key="ActionButtonBlueStyle" TargetType="Button">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#0078d4" />
+                    </Setter.Value>
+                </Setter>
+                <Setter Property="Foreground" Value="White" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="Padding" Value="14,5" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Margin" Value="0,0,8,0" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Bd" Background="{TemplateBinding Background}"
+                                    CornerRadius="2" Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background">
+                                        <Setter.Value>
+                                            <SolidColorBrush Color="#026ec1" />
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Action button style (red uninstall/disable) -->
+            <Style x:Key="ActionButtonRedStyle" TargetType="Button" BasedOn="{StaticResource ActionButtonBlueStyle}">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#c42b1c" />
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background">
+                            <Setter.Value>
+                                <SolidColorBrush Color="#a12316" />
+                            </Setter.Value>
+                        </Setter>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <!-- Detail tab header style -->
+            <Style x:Key="DetailTabStyle" TargetType="Border">
+                <Setter Property="Padding" Value="12,6" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Background" Value="Transparent" />
+            </Style>
+
+            <!-- Settings cog for header -->
+            <Style x:Key="HeaderSettingsCogStyle" TargetType="Button">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Width" Value="20" />
+                <Setter Property="Height" Value="20" />
+                <Setter Property="Margin" Value="8,0,0,0" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent">
+                                <Path x:Name="CogIcon"
+                                      Data="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.04 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.04 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
+                                      Fill="{DynamicResource SecondaryForegroundBrush}"
+                                      Stretch="Uniform" Width="16" Height="16" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="CogIcon" Property="Fill"
+                                            Value="{DynamicResource PrimaryForegroundBrush}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Metadata label style -->
+            <Style x:Key="MetadataLabelStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource SecondaryForegroundBrush}" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="11" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="Margin" Value="0,8,0,2" />
+            </Style>
+
+            <!-- Metadata value style -->
+            <Style x:Key="MetadataValueStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="TextWrapping" Value="Wrap" />
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <!-- Header -->
+            <RowDefinition Height="Auto" />
+            <!-- Content -->
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!-- ═══ HEADER ═══ -->
+        <Border Grid.Row="0" Padding="20,16"
+                BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                BorderThickness="0,0,0,1">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <!-- Large plugin icon -->
+                <Border Grid.Column="0" Width="64" Height="64"
+                        CornerRadius="6" Background="#2a2a2a"
+                        VerticalAlignment="Top" Margin="0,0,16,0">
+                    <Path Data="M 6,2 L 6,14 L 14,14 L 14,6 L 10,2 Z"
+                          Stroke="{DynamicResource SecondaryForegroundBrush}"
+                          StrokeThickness="1.5" Fill="Transparent"
+                          Stretch="Uniform" Width="28" Height="28"
+                          HorizontalAlignment="Center" VerticalAlignment="Center" />
+                </Border>
+
+                <!-- Title, publisher, description, buttons -->
+                <StackPanel Grid.Column="1">
+                    <!-- Title -->
+                    <TextBlock x:Name="HeaderTitle"
+                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                               FontFamily="Segoe UI" FontSize="20" FontWeight="Bold"
+                               TextTrimming="CharacterEllipsis" />
+
+                    <!-- Publisher with verified badge -->
+                    <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                        <TextBlock x:Name="HeaderPublisher"
+                                   Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                   FontFamily="Segoe UI" FontSize="12" />
+                        <Canvas x:Name="HeaderVerifiedBadge" Width="14" Height="14"
+                                Margin="4,0,0,0" VerticalAlignment="Center" Visibility="Collapsed">
+                            <Ellipse Width="14" Height="14" Fill="{DynamicResource AccentBrush}" />
+                            <Path Data="M 3.5,7 L 6,9.5 L 10.5,5"
+                                  Stroke="#1e1e1e" StrokeThickness="1.5"
+                                  StrokeLineJoin="Round" Fill="Transparent" />
+                        </Canvas>
+                    </StackPanel>
+
+                    <!-- Short description -->
+                    <TextBlock x:Name="HeaderDescription"
+                               Foreground="{DynamicResource SecondaryForegroundBrush}"
+                               FontFamily="Segoe UI" FontSize="12"
+                               TextWrapping="Wrap" Margin="0,4,0,0" />
+
+                    <!-- Action buttons -->
+                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                        <Button x:Name="InstallUninstallButton"
+                                Style="{StaticResource ActionButtonBlueStyle}"
+                                Click="OnInstallUninstallClick" />
+                        <Button x:Name="EnableDisableButton"
+                                Style="{StaticResource ActionButtonBlueStyle}"
+                                Click="OnEnableDisableClick" />
+                        <Button x:Name="SettingsGearButton"
+                                Style="{StaticResource HeaderSettingsCogStyle}"
+                                Click="OnHeaderSettingsClick"
+                                ToolTip="Plugin Settings" />
+                    </StackPanel>
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <!-- ═══ CONTENT AREA ═══ -->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <!-- Left content (75%) -->
+                <ColumnDefinition Width="3*" />
+                <!-- Right metadata (25%) -->
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <!-- LEFT: Tabbed content -->
+            <Grid Grid.Column="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+
+                <!-- Tab strip -->
+                <Border Grid.Row="0" BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                        BorderThickness="0,0,0,1">
+                    <StackPanel Orientation="Horizontal" Margin="12,0,0,0">
+                        <Border x:Name="DetailsTabHeader" Style="{StaticResource DetailTabStyle}"
+                                MouseLeftButtonDown="OnDetailsTabClick">
+                            <TextBlock x:Name="DetailsTabText" Text="Details"
+                                       FontFamily="Segoe UI" FontSize="13"
+                                       Foreground="{DynamicResource PrimaryForegroundBrush}" />
+                        </Border>
+                        <Border x:Name="ChangelogTabHeader" Style="{StaticResource DetailTabStyle}"
+                                MouseLeftButtonDown="OnChangelogTabClick">
+                            <TextBlock x:Name="ChangelogTabText" Text="Changelog"
+                                       FontFamily="Segoe UI" FontSize="13"
+                                       Foreground="{DynamicResource SecondaryForegroundBrush}" />
+                        </Border>
+                        <Border x:Name="SettingsTabHeader" Style="{StaticResource DetailTabStyle}"
+                                MouseLeftButtonDown="OnSettingsTabClick">
+                            <TextBlock x:Name="SettingsTabText" Text="Settings"
+                                       FontFamily="Segoe UI" FontSize="13"
+                                       Foreground="{DynamicResource SecondaryForegroundBrush}" />
+                        </Border>
+                    </StackPanel>
+                </Border>
+
+                <!-- Tab content area -->
+                <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled">
+                    <Grid>
+                        <!-- Details tab content -->
+                        <StackPanel x:Name="DetailsContent" Margin="20,12">
+                            <TextBlock x:Name="DetailsText"
+                                       Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                       FontFamily="Segoe UI" FontSize="13"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+
+                        <!-- Changelog tab content -->
+                        <StackPanel x:Name="ChangelogContent" Margin="20,12" Visibility="Collapsed">
+                            <TextBlock x:Name="ChangelogText"
+                                       Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                       FontFamily="Segoe UI" FontSize="13"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+
+                        <!-- Settings tab content -->
+                        <StackPanel x:Name="SettingsContent" Margin="20,12" Visibility="Collapsed">
+                            <TextBlock x:Name="NoSettingsText"
+                                       Text="This plugin has no configurable settings."
+                                       Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                       FontFamily="Segoe UI" FontSize="13" Visibility="Collapsed" />
+                            <ItemsControl x:Name="SettingsItemsControl">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Margin="0,0,0,16">
+                                            <!-- Section header (if different from previous) -->
+                                            <Border x:Name="SectionHeader" Visibility="Collapsed"
+                                                    Margin="0,8,0,8">
+                                                <StackPanel>
+                                                    <Border Height="1"
+                                                            Background="{DynamicResource PanelSeparatorBrush}"
+                                                            Margin="0,0,0,8" />
+                                                    <TextBlock Text="{Binding Section}"
+                                                               Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                                               FontFamily="Segoe UI" FontSize="13"
+                                                               FontWeight="SemiBold" />
+                                                </StackPanel>
+                                            </Border>
+
+                                            <!-- Setting title -->
+                                            <TextBlock Text="{Binding Title}"
+                                                       Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                       FontFamily="Segoe UI" FontSize="13"
+                                                       FontWeight="SemiBold"
+                                                       Margin="0,0,0,2" />
+
+                                            <!-- Setting description -->
+                                            <TextBlock Text="{Binding Description}"
+                                                       Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                                       FontFamily="Segoe UI" FontSize="12"
+                                                       TextWrapping="Wrap"
+                                                       Margin="0,0,0,6" />
+
+                                            <!-- Boolean → ComboBox (True/False) -->
+                                            <ComboBox ItemsSource="{Binding BooleanOptions}"
+                                                      SelectedItem="{Binding SelectedBooleanValue}"
+                                                      Visibility="{Binding IsBoolean, Converter={StaticResource BoolToVis}}"
+                                                      Width="120" HorizontalAlignment="Left"
+                                                      Background="{DynamicResource InputBackgroundBrush}"
+                                                      Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                      BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                                                      FontFamily="Segoe UI" FontSize="13" />
+
+                                            <!-- Number → TextBox (numeric only) -->
+                                            <TextBox Text="{Binding StringValue, UpdateSourceTrigger=PropertyChanged}"
+                                                     Visibility="{Binding IsNumber, Converter={StaticResource BoolToVis}}"
+                                                     Width="120" HorizontalAlignment="Left"
+                                                     Background="{DynamicResource InputBackgroundBrush}"
+                                                     Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                     CaretBrush="{DynamicResource PrimaryForegroundBrush}"
+                                                     BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                                                     FontFamily="Segoe UI" FontSize="13"
+                                                     Padding="4,4"
+                                                     PreviewTextInput="OnNumericPreviewTextInput" />
+
+                                            <!-- String → TextBox -->
+                                            <TextBox Text="{Binding StringValue, UpdateSourceTrigger=PropertyChanged}"
+                                                     Visibility="{Binding IsString, Converter={StaticResource BoolToVis}}"
+                                                     Width="300" HorizontalAlignment="Left"
+                                                     Background="{DynamicResource InputBackgroundBrush}"
+                                                     Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                     CaretBrush="{DynamicResource PrimaryForegroundBrush}"
+                                                     BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                                                     FontFamily="Segoe UI" FontSize="13"
+                                                     Padding="4,4" />
+
+                                            <!-- Enum → ComboBox -->
+                                            <ComboBox ItemsSource="{Binding EnumValues}"
+                                                      SelectedItem="{Binding SelectedEnumValue}"
+                                                      Visibility="{Binding IsEnum, Converter={StaticResource BoolToVis}}"
+                                                      Width="200" HorizontalAlignment="Left"
+                                                      Background="{DynamicResource InputBackgroundBrush}"
+                                                      Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                      BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                                                      FontFamily="Segoe UI" FontSize="13" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </StackPanel>
+                    </Grid>
+                </ScrollViewer>
+            </Grid>
+
+            <!-- Separator between left and right -->
+            <Border Grid.Column="0" HorizontalAlignment="Right" Width="1"
+                    Background="{DynamicResource PrimaryBorderBrush}" />
+
+            <!-- RIGHT: Metadata pane -->
+            <ScrollViewer Grid.Column="1" VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <StackPanel Margin="16,12">
+                    <TextBlock Text="Version" Style="{StaticResource MetadataLabelStyle}" />
+                    <TextBlock x:Name="MetaVersion" Style="{StaticResource MetadataValueStyle}" />
+
+                    <TextBlock Text="Tags" Style="{StaticResource MetadataLabelStyle}" />
+                    <TextBlock x:Name="MetaTags" Style="{StaticResource MetadataValueStyle}" />
+
+                    <TextBlock Text="Last Updated" Style="{StaticResource MetadataLabelStyle}" />
+                    <TextBlock x:Name="MetaLastUpdated" Style="{StaticResource MetadataValueStyle}" />
+
+                    <TextBlock Text="License" Style="{StaticResource MetadataLabelStyle}" />
+                    <TextBlock x:Name="MetaLicense" Style="{StaticResource MetadataValueStyle}" />
+                </StackPanel>
+            </ScrollViewer>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Vido.Views/Panels/PluginDetailPanel.xaml.cs
+++ b/src/Vido.Views/Panels/PluginDetailPanel.xaml.cs
@@ -1,0 +1,357 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using Vido.Core.Logging;
+using Vido.Core.Plugin;
+using Vido.ViewModels;
+
+namespace Vido.Views.Panels;
+
+/// <summary>
+/// Detail panel for a single plugin. Shown as a tab in the main editor area.
+/// Displays header with action buttons, tabbed content (Details/Changelog/Settings),
+/// and right-side metadata pane.
+/// </summary>
+public partial class PluginDetailPanel : UserControl
+{
+    private readonly PluginItemViewModel? _item;
+    private readonly PluginManagerViewModel? _managerVm;
+    private readonly IPluginHost? _pluginHost;
+    private readonly ILogService? _logService;
+    private string _activeTab = "Details";
+
+    public PluginDetailPanel(
+        PluginItemViewModel? item,
+        PluginManagerViewModel? managerVm,
+        IPluginHost? pluginHost,
+        ILogService? logService)
+    {
+        _item = item;
+        _managerVm = managerVm;
+        _pluginHost = pluginHost;
+        _logService = logService;
+
+        InitializeComponent();
+
+        if (item is not null)
+        {
+            PopulateHeader();
+            PopulateMetadata();
+            LoadContent();
+            SubscribeToChanges();
+        }
+    }
+
+    /// <summary>
+    /// Populates the header section with plugin info.
+    /// </summary>
+    private void PopulateHeader()
+    {
+        if (_item is null) return;
+
+        HeaderTitle.Text = _item.DisplayName;
+        HeaderPublisher.Text = _item.Publisher;
+        HeaderDescription.Text = _item.Description;
+        HeaderVerifiedBadge.Visibility = _item.IsOfficial ? Visibility.Visible : Visibility.Collapsed;
+
+        UpdateActionButtons();
+    }
+
+    /// <summary>
+    /// Updates the install/uninstall and enable/disable button states.
+    /// </summary>
+    private void UpdateActionButtons()
+    {
+        if (_item is null) return;
+
+        if (_item.IsInstalled)
+        {
+            InstallUninstallButton.Content = "Uninstall";
+            InstallUninstallButton.Style = (Style)FindResource("ActionButtonRedStyle");
+
+            EnableDisableButton.Content = _item.IsEnabled ? "Disable" : "Enable";
+            EnableDisableButton.Style = _item.IsEnabled
+                ? (Style)FindResource("ActionButtonRedStyle")
+                : (Style)FindResource("ActionButtonBlueStyle");
+            EnableDisableButton.Visibility = Visibility.Visible;
+            SettingsGearButton.Visibility = Visibility.Visible;
+        }
+        else
+        {
+            InstallUninstallButton.Content = "Install";
+            InstallUninstallButton.Style = (Style)FindResource("ActionButtonBlueStyle");
+            EnableDisableButton.Visibility = Visibility.Collapsed;
+            SettingsGearButton.Visibility = Visibility.Collapsed;
+        }
+    }
+
+    /// <summary>
+    /// Populates the right-side metadata pane.
+    /// </summary>
+    private void PopulateMetadata()
+    {
+        if (_item is null) return;
+
+        MetaVersion.Text = _item.Version;
+        MetaTags.Text = _item.Tags.Count > 0 ? string.Join(", ", _item.Tags) : "—";
+        MetaLastUpdated.Text = _item.LastUpdated ?? "—";
+        MetaLicense.Text = !string.IsNullOrWhiteSpace(_item.License) ? _item.License : "—";
+    }
+
+    /// <summary>
+    /// Loads README.md and CHANGELOG.md content from the plugin directory.
+    /// </summary>
+    private void LoadContent()
+    {
+        if (_item is null) return;
+
+        // Load README.md
+        var readme = TryReadPluginFile("README.md");
+        DetailsText.Text = !string.IsNullOrWhiteSpace(readme)
+            ? readme
+            : "No details available.";
+
+        // Load CHANGELOG.md
+        var changelog = TryReadPluginFile("CHANGELOG.md");
+        ChangelogText.Text = !string.IsNullOrWhiteSpace(changelog)
+            ? changelog
+            : "No changelog available.";
+
+        // Load settings
+        LoadSettings();
+    }
+
+    /// <summary>
+    /// Reads a file from the plugin directory. Returns null if not found or on error.
+    /// </summary>
+    private string? TryReadPluginFile(string filename)
+    {
+        if (_item?.PluginInfo?.Directory is null) return null;
+
+        var path = Path.Combine(_item.PluginInfo.Directory, filename);
+        if (!File.Exists(path)) return null;
+
+        try
+        {
+            return File.ReadAllText(path);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Loads and displays plugin settings.
+    /// </summary>
+    private void LoadSettings()
+    {
+        if (_item?.PluginInfo is null)
+        {
+            NoSettingsText.Visibility = Visibility.Visible;
+            NoSettingsText.Text = _item?.IsInstalled == true
+                ? "This plugin has no configurable settings."
+                : "Install this plugin to configure its settings.";
+            return;
+        }
+
+        var manifest = _item.PluginInfo.Manifest;
+        var settings = manifest.Contributes.Settings;
+
+        if (settings.Count == 0)
+        {
+            NoSettingsText.Visibility = Visibility.Visible;
+            return;
+        }
+
+        try
+        {
+            // Get or create a settings store for this plugin
+            // We use the PluginHost to find the actual IPluginHost at runtime
+            // For now, create a direct store based on the plugin ID
+            IPluginSettingsStore? store = null;
+
+            // Try to get the store from the PluginHost via the manager VM
+            if (_managerVm is not null)
+            {
+                // The manager VM has access to IPluginHost
+                store = GetSettingsStoreFromHost(_item.Id);
+            }
+
+            if (store is null)
+            {
+                NoSettingsText.Visibility = Visibility.Visible;
+                NoSettingsText.Text = "Unable to load settings.";
+                return;
+            }
+
+            // Build display items for each setting
+            var displayItems = new List<SettingDisplayItem>();
+
+            foreach (var setting in settings)
+            {
+                var displayItem = new SettingDisplayItem(setting, store);
+                displayItems.Add(displayItem);
+            }
+
+            SettingsItemsControl.ItemsSource = displayItems;
+            NoSettingsText.Visibility = Visibility.Collapsed;
+
+            // Handle section headers via code-behind after items are loaded
+            SettingsItemsControl.Loaded += (_, _) => ApplySectionHeaders(displayItems);
+        }
+        catch (Exception ex)
+        {
+            _logService?.Error($"Failed to load settings for plugin '{_item.Id}': {ex.Message}", "PluginDetail");
+            NoSettingsText.Visibility = Visibility.Visible;
+            NoSettingsText.Text = "Failed to load settings.";
+        }
+    }
+
+    /// <summary>
+    /// Gets the settings store from the IPluginHost.
+    /// </summary>
+    private IPluginSettingsStore? GetSettingsStoreFromHost(string pluginId)
+    {
+        return _pluginHost?.GetSettingsStore(pluginId);
+    }
+
+    /// <summary>
+    /// Shows section headers for settings that belong to different sections.
+    /// </summary>
+    private void ApplySectionHeaders(List<SettingDisplayItem> items)
+    {
+        string? lastSection = null;
+        for (int i = 0; i < items.Count; i++)
+        {
+            var item = items[i];
+            if (item.Section is not null && item.Section != lastSection)
+            {
+                lastSection = item.Section;
+                // Find the container and show its section header
+                var container = SettingsItemsControl.ItemContainerGenerator.ContainerFromIndex(i);
+                if (container is ContentPresenter cp)
+                {
+                    var header = FindChild<Border>(cp, "SectionHeader");
+                    if (header is not null)
+                        header.Visibility = Visibility.Visible;
+                }
+            }
+            else if (item.Section is null || item.Section == lastSection)
+            {
+                lastSection = item.Section;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Subscribes to PropertyChanged on the PluginItemViewModel to update the UI in real-time.
+    /// </summary>
+    private void SubscribeToChanges()
+    {
+        if (_item is null) return;
+
+        _item.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName is nameof(PluginItemViewModel.IsInstalled)
+                or nameof(PluginItemViewModel.IsEnabled))
+            {
+                Dispatcher.Invoke(UpdateActionButtons);
+            }
+        };
+    }
+
+    /// <summary>
+    /// Switches to the Settings tab.
+    /// </summary>
+    public void SwitchToSettings()
+    {
+        SetActiveTab("Settings");
+    }
+
+    /// <summary>
+    /// Sets the active tab (Details, Changelog, or Settings).
+    /// </summary>
+    private void SetActiveTab(string tabName)
+    {
+        _activeTab = tabName;
+
+        // Update tab header appearance
+        var activeBrush = (Brush)FindResource("PrimaryForegroundBrush");
+        var inactiveBrush = (Brush)FindResource("SecondaryForegroundBrush");
+
+        DetailsTabText.Foreground = tabName == "Details" ? activeBrush : inactiveBrush;
+        ChangelogTabText.Foreground = tabName == "Changelog" ? activeBrush : inactiveBrush;
+        SettingsTabText.Foreground = tabName == "Settings" ? activeBrush : inactiveBrush;
+
+        // Toggle content visibility
+        DetailsContent.Visibility = tabName == "Details" ? Visibility.Visible : Visibility.Collapsed;
+        ChangelogContent.Visibility = tabName == "Changelog" ? Visibility.Visible : Visibility.Collapsed;
+        SettingsContent.Visibility = tabName == "Settings" ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    // ── Click handlers ──
+
+    private void OnDetailsTabClick(object sender, MouseButtonEventArgs e) => SetActiveTab("Details");
+    private void OnChangelogTabClick(object sender, MouseButtonEventArgs e) => SetActiveTab("Changelog");
+    private void OnSettingsTabClick(object sender, MouseButtonEventArgs e) => SetActiveTab("Settings");
+
+    private async void OnInstallUninstallClick(object sender, RoutedEventArgs e)
+    {
+        if (_item is null || _managerVm is null) return;
+
+        if (_item.IsInstalled)
+            await _managerVm.UninstallPluginAsync(_item);
+        else
+            await _managerVm.InstallPluginAsync(_item);
+    }
+
+    private void OnEnableDisableClick(object sender, RoutedEventArgs e)
+    {
+        if (_item is null || _managerVm is null) return;
+        _managerVm.ToggleEnabled(_item);
+    }
+
+    private void OnHeaderSettingsClick(object sender, RoutedEventArgs e)
+    {
+        SwitchToSettings();
+    }
+
+    /// <summary>
+    /// Restricts input to numeric characters only (digits, decimal point, minus sign).
+    /// </summary>
+    private void OnNumericPreviewTextInput(object sender, TextCompositionEventArgs e)
+    {
+        e.Handled = !IsNumericInput(e.Text);
+    }
+
+    private static bool IsNumericInput(string text)
+    {
+        return NumericRegex().IsMatch(text);
+    }
+
+    [GeneratedRegex(@"^[\d.\-]$")]
+    private static partial Regex NumericRegex();
+
+    /// <summary>
+    /// Finds a named child element in the visual tree.
+    /// </summary>
+    private static T? FindChild<T>(DependencyObject parent, string name) where T : FrameworkElement
+    {
+        var count = VisualTreeHelper.GetChildrenCount(parent);
+        for (int i = 0; i < count; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T fe && fe.Name == name)
+                return fe;
+
+            var result = FindChild<T>(child, name);
+            if (result is not null)
+                return result;
+        }
+        return null;
+    }
+}

--- a/src/Vido.Views/Panels/PluginManagerPanel.xaml
+++ b/src/Vido.Views/Panels/PluginManagerPanel.xaml
@@ -1,0 +1,553 @@
+<UserControl x:Class="Vido.Views.Panels.PluginManagerPanel"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Vido.ViewModels;assembly=Vido.ViewModels"
+             Background="{DynamicResource SidebarBackgroundBrush}">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Themes/Brushes.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+            <BooleanToVisibilityConverter x:Key="BoolToVis" />
+
+            <!-- Chevron toggle for collapsible sections -->
+            <Style x:Key="SectionChevronStyle" TargetType="ToggleButton">
+                <Setter Property="Focusable" Value="False" />
+                <Setter Property="Width" Value="16" />
+                <Setter Property="Height" Value="22" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ToggleButton">
+                            <Border Background="Transparent" Width="16" Height="22">
+                                <Path x:Name="Arrow"
+                                      Data="M 4,2 L 10,6 4,10"
+                                      Stroke="{DynamicResource SecondaryForegroundBrush}"
+                                      StrokeThickness="1.2"
+                                      StrokeLineJoin="Round"
+                                      StrokeStartLineCap="Round"
+                                      StrokeEndLineCap="Round"
+                                      Fill="Transparent"
+                                      HorizontalAlignment="Center"
+                                      VerticalAlignment="Center"
+                                      RenderTransformOrigin="0.5,0.5">
+                                    <Path.RenderTransform>
+                                        <RotateTransform Angle="0" />
+                                    </Path.RenderTransform>
+                                </Path>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter TargetName="Arrow" Property="RenderTransform">
+                                        <Setter.Value>
+                                            <RotateTransform Angle="90" />
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Count badge (gray circle with white number) -->
+            <Style x:Key="CountBadgeStyle" TargetType="Border">
+                <Setter Property="Background" Value="#5a5a5a" />
+                <Setter Property="CornerRadius" Value="8" />
+                <Setter Property="MinWidth" Value="18" />
+                <Setter Property="Height" Value="18" />
+                <Setter Property="Padding" Value="4,0" />
+                <Setter Property="Margin" Value="6,0,0,0" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+            </Style>
+
+            <!-- Install button style -->
+            <Style x:Key="InstallButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="{DynamicResource ButtonBackgroundBrush}" />
+                <Setter Property="Foreground" Value="White" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="11" />
+                <Setter Property="Padding" Value="8,2" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Bd"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="4"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Bd" Property="Background"
+                                            Value="{DynamicResource ButtonHoverBackgroundBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="Bd" Property="Opacity" Value="0.5" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Uninstall button style -->
+            <Style x:Key="UninstallButtonStyle" TargetType="Button" BasedOn="{StaticResource InstallButtonStyle}">
+                <Setter Property="Background">
+                    <Setter.Value>
+                        <SolidColorBrush Color="#c42b1c" />
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Settings cog button style (chromeless) -->
+            <Style x:Key="SettingsCogStyle" TargetType="Button">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Width" Value="16" />
+                <Setter Property="Height" Value="16" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent" Padding="0">
+                                <Path x:Name="CogIcon"
+                                      Data="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.04 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.04 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
+                                      Fill="{DynamicResource SecondaryForegroundBrush}"
+                                      Stretch="Uniform" Width="14" Height="14" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="CogIcon" Property="Fill"
+                                            Value="{DynamicResource PrimaryForegroundBrush}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Status pill style -->
+            <Style x:Key="StatusPillStyle" TargetType="Border">
+                <Setter Property="CornerRadius" Value="3" />
+                <Setter Property="Padding" Value="5,1" />
+                <Setter Property="Margin" Value="4,0,0,0" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+            </Style>
+
+            <!-- Plugin item hover background -->
+            <Style x:Key="PluginItemBorderStyle" TargetType="Border">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Padding" Value="8,6" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource HoverBackgroundBrush}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
+            <!-- Dark Modern ComboBox ToggleButton (arrow area) -->
+            <ControlTemplate x:Key="DarkComboBoxToggleButton" TargetType="ToggleButton">
+                <Border Background="Transparent">
+                    <Path x:Name="Arrow"
+                          Data="M 0,0 L 4,4 L 8,0"
+                          Stroke="{DynamicResource SecondaryForegroundBrush}"
+                          StrokeThickness="1.2"
+                          HorizontalAlignment="Right"
+                          VerticalAlignment="Center"
+                          Margin="0,0,8,0" />
+                </Border>
+                <ControlTemplate.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter TargetName="Arrow" Property="Stroke"
+                                Value="{DynamicResource PrimaryForegroundBrush}" />
+                    </Trigger>
+                </ControlTemplate.Triggers>
+            </ControlTemplate>
+
+            <!-- Dark Modern ComboBox Style -->
+            <Style x:Key="DarkComboBoxStyle" TargetType="ComboBox">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="13" />
+                <Setter Property="SnapsToDevicePixels" Value="True" />
+                <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ComboBox">
+                            <Grid>
+                                <!-- Toggle button covers the full area -->
+                                <ToggleButton x:Name="ToggleBtn"
+                                              Template="{StaticResource DarkComboBoxToggleButton}"
+                                              IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                              Focusable="False"
+                                              ClickMode="Press" />
+
+                                <!-- Selected item display -->
+                                <ContentPresenter x:Name="ContentSite"
+                                                  IsHitTestVisible="False"
+                                                  Content="{TemplateBinding SelectionBoxItem}"
+                                                  ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                                  Margin="8,4,24,4"
+                                                  VerticalAlignment="Center"
+                                                  HorizontalAlignment="Left" />
+
+                                <!-- Dropdown popup -->
+                                <Popup x:Name="Popup"
+                                       Placement="Bottom"
+                                       IsOpen="{TemplateBinding IsDropDownOpen}"
+                                       AllowsTransparency="True"
+                                       Focusable="False"
+                                       PopupAnimation="Slide">
+                                    <Grid x:Name="DropDown"
+                                          MinWidth="{TemplateBinding ActualWidth}"
+                                          MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                                          SnapsToDevicePixels="True">
+                                        <Border x:Name="DropDownBorder"
+                                                Background="{DynamicResource InputBackgroundBrush}"
+                                                BorderBrush="{DynamicResource FocusBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="4"
+                                                Margin="0,2,0,0"
+                                                Padding="0,4">
+                                            <ScrollViewer SnapsToDevicePixels="True">
+                                                <StackPanel IsItemsHost="True"
+                                                            KeyboardNavigation.DirectionalNavigation="Contained" />
+                                            </ScrollViewer>
+                                        </Border>
+                                    </Grid>
+                                </Popup>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Dark Modern ComboBoxItem Style -->
+            <Style x:Key="DarkComboBoxItemStyle" TargetType="ComboBoxItem">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryForegroundBrush}" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="FontSize" Value="13" />
+                <Setter Property="Padding" Value="8,4" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Cursor" Value="Hand" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ComboBoxItem">
+                            <Border x:Name="Bd"
+                                    Background="{TemplateBinding Background}"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsHighlighted" Value="True">
+                                    <Setter TargetName="Bd" Property="Background"
+                                            Value="{DynamicResource HoverBackgroundBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsSelected" Value="True">
+                                    <Setter TargetName="Bd" Property="Background"
+                                            Value="{DynamicResource SelectionBackgroundBrush}" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid>
+        <DockPanel>
+            <!-- Registry dropdown -->
+            <Border x:Name="DropdownBorder" DockPanel.Dock="Top" Margin="8,4,8,4"
+                    Background="{DynamicResource InputBackgroundBrush}"
+                    BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                    BorderThickness="1" CornerRadius="4" Padding="0">
+                <ComboBox x:Name="RegistryDropdown"
+                          Style="{StaticResource DarkComboBoxStyle}"
+                          ItemContainerStyle="{StaticResource DarkComboBoxItemStyle}"
+                          ItemsSource="{Binding RegistrySources}"
+                          SelectedItem="{Binding SelectedRegistrySource}"
+                          GotFocus="OnDropdownGotFocus" LostFocus="OnDropdownLostFocus"
+                          DropDownOpened="OnDropdownOpened" DropDownClosed="OnDropdownClosed" />
+            </Border>
+
+            <!-- Search bar -->
+            <Border x:Name="SearchBorder" DockPanel.Dock="Top" Margin="8,0,8,4"
+                    Background="{DynamicResource InputBackgroundBrush}"
+                    BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                    BorderThickness="1" CornerRadius="4" Padding="4,0">
+                <DockPanel>
+                    <!-- Magnifying glass icon -->
+                    <Path DockPanel.Dock="Left"
+                          Data="M15.25 0a8.25 8.25 0 0 0-6.18 13.72L1 21.75l1.27 1.27 8.05-8.04a8.25 8.25 0 1 0 4.93-14.98zm0 14.5a6.25 6.25 0 1 1 0-12.5 6.25 6.25 0 0 1 0 12.5z"
+                          Fill="{DynamicResource SecondaryForegroundBrush}"
+                          Stretch="Uniform" Width="14" Height="14"
+                          Margin="2,0,4,0" VerticalAlignment="Center" />
+                    <TextBox x:Name="SearchBox"
+                             Text="{Binding SearchQuery, UpdateSourceTrigger=PropertyChanged}"
+                             Background="Transparent"
+                             Foreground="{DynamicResource PrimaryForegroundBrush}"
+                             CaretBrush="{DynamicResource PrimaryForegroundBrush}"
+                             BorderThickness="0"
+                             FontFamily="Segoe UI" FontSize="13"
+                             VerticalContentAlignment="Center"
+                             Padding="2,4"
+                             GotFocus="OnSearchBoxGotFocus" LostFocus="OnSearchBoxLostFocus" />
+                </DockPanel>
+            </Border>
+
+            <!-- Loading indicator -->
+            <TextBlock DockPanel.Dock="Top"
+                       Text="Loading plugins..."
+                       Foreground="{DynamicResource SecondaryForegroundBrush}"
+                       FontFamily="Segoe UI" FontSize="12"
+                       HorizontalAlignment="Center" Margin="0,8"
+                       Visibility="{Binding IsLoading, Converter={StaticResource BoolToVis}}" />
+
+            <!-- Scrollable content area -->
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <StackPanel>
+                    <!-- ═══ INSTALLED Section ═══ -->
+                    <Border BorderBrush="{DynamicResource PrimaryBorderBrush}"
+                            BorderThickness="0,0,0,1">
+                        <!-- Section header -->
+                        <DockPanel Margin="0">
+                            <Border DockPanel.Dock="Top"
+                                    Background="{DynamicResource SidebarBackgroundBrush}"
+                                    Padding="4,4" Cursor="Hand"
+                                    MouseLeftButtonDown="OnInstalledHeaderClick">
+                                <DockPanel>
+                                    <ToggleButton x:Name="InstalledChevron"
+                                                  Style="{StaticResource SectionChevronStyle}"
+                                                  IsChecked="{Binding IsInstalledExpanded}" />
+                                    <TextBlock Text="INSTALLED"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                               FontFamily="Segoe UI" FontSize="11"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center"
+                                               Margin="2,0,0,0" />
+                                    <Border Style="{StaticResource CountBadgeStyle}">
+                                        <TextBlock Text="{Binding InstalledCount}"
+                                                   Foreground="White"
+                                                   FontFamily="Segoe UI" FontSize="10"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
+                                </DockPanel>
+                            </Border>
+
+                            <!-- Installed items list -->
+                            <ItemsControl ItemsSource="{Binding InstalledPlugins}"
+                                          Visibility="{Binding IsInstalledExpanded, Converter={StaticResource BoolToVis}}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:PluginItemViewModel}">
+                                        <Border Style="{StaticResource PluginItemBorderStyle}"
+                                                MouseLeftButtonDown="OnPluginItemClick"
+                                                Cursor="Hand">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="36" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <!-- Plugin icon -->
+                                                <Border Grid.Column="0" Width="32" Height="32"
+                                                        CornerRadius="4" Background="#2a2a2a"
+                                                        VerticalAlignment="Top" Margin="0,2,0,0">
+                                                    <Path Data="M 6,2 L 6,14 L 14,14 L 14,6 L 10,2 Z"
+                                                          Stroke="{DynamicResource SecondaryForegroundBrush}"
+                                                          StrokeThickness="1" Fill="Transparent"
+                                                          Stretch="Uniform" Width="16" Height="16"
+                                                          HorizontalAlignment="Center"
+                                                          VerticalAlignment="Center" />
+                                                </Border>
+
+                                                <!-- Title, description, publisher -->
+                                                <StackPanel Grid.Column="1" Margin="4,0,4,0">
+                                                    <TextBlock Text="{Binding DisplayName}"
+                                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                               FontFamily="Segoe UI" FontSize="13"
+                                                               FontWeight="Bold"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding Description}"
+                                                               Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                                               FontFamily="Segoe UI" FontSize="11.5"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               Margin="0,1,0,0" />
+                                                    <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                                        <TextBlock Text="{Binding Publisher}"
+                                                                   Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                                                   FontFamily="Segoe UI" FontSize="10.5" />
+                                                        <!-- Verified badge (official only) -->
+                                                        <Canvas Width="14" Height="14" Margin="4,0,0,0"
+                                                                VerticalAlignment="Center"
+                                                                Visibility="{Binding IsOfficial, Converter={StaticResource BoolToVis}}">
+                                                            <Ellipse Width="14" Height="14"
+                                                                     Fill="{DynamicResource AccentBrush}" />
+                                                            <Path Data="M 3.5,7 L 6,9.5 L 10.5,5"
+                                                                  Stroke="#1e1e1e" StrokeThickness="1.5"
+                                                                  StrokeLineJoin="Round" Fill="Transparent"
+                                                                  Canvas.Left="0" Canvas.Top="0" />
+                                                        </Canvas>
+                                                    </StackPanel>
+                                                </StackPanel>
+
+                                                <!-- Right side: settings cog, status, uninstall -->
+                                                <StackPanel Grid.Column="2" VerticalAlignment="Top"
+                                                            HorizontalAlignment="Right" Margin="0,2,0,0">
+                                                    <!-- Enable/Disable status pill -->
+                                                    <Border Style="{StaticResource StatusPillStyle}">
+                                                        <Border.Background>
+                                                            <SolidColorBrush Color="#2a2a2a" />
+                                                        </Border.Background>
+                                                        <TextBlock Text="{Binding StatusText}"
+                                                                   FontFamily="Segoe UI" FontSize="10"
+                                                                   HorizontalAlignment="Center">
+                                                            <TextBlock.Style>
+                                                                <Style TargetType="TextBlock">
+                                                                    <Setter Property="Foreground" Value="{DynamicResource SuccessForegroundBrush}" />
+                                                                    <Style.Triggers>
+                                                                        <DataTrigger Binding="{Binding IsEnabled}" Value="False">
+                                                                            <Setter Property="Foreground" Value="{DynamicResource SecondaryForegroundBrush}" />
+                                                                        </DataTrigger>
+                                                                    </Style.Triggers>
+                                                                </Style>
+                                                            </TextBlock.Style>
+                                                        </TextBlock>
+                                                    </Border>
+
+                                                    <!-- Settings cog + Uninstall row -->
+                                                    <StackPanel Orientation="Horizontal"
+                                                                HorizontalAlignment="Right"
+                                                                Margin="0,4,0,0">
+                                                        <Button Style="{StaticResource SettingsCogStyle}"
+                                                                Click="OnSettingsCogClick"
+                                                                ToolTip="Plugin Settings"
+                                                                Margin="0,0,6,0" />
+                                                        <Button Style="{StaticResource UninstallButtonStyle}"
+                                                                Content="Uninstall"
+                                                                Click="OnUninstallClick"
+                                                                ToolTip="Uninstall plugin" />
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </DockPanel>
+                    </Border>
+
+                    <!-- ═══ AVAILABLE Section ═══ -->
+                    <Border>
+                        <DockPanel Margin="0">
+                            <!-- Section header -->
+                            <Border DockPanel.Dock="Top"
+                                    Background="{DynamicResource SidebarBackgroundBrush}"
+                                    Padding="4,4" Cursor="Hand"
+                                    MouseLeftButtonDown="OnAvailableHeaderClick">
+                                <DockPanel>
+                                    <ToggleButton x:Name="AvailableChevron"
+                                                  Style="{StaticResource SectionChevronStyle}"
+                                                  IsChecked="{Binding IsAvailableExpanded}" />
+                                    <TextBlock Text="AVAILABLE"
+                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                               FontFamily="Segoe UI" FontSize="11"
+                                               FontWeight="SemiBold"
+                                               VerticalAlignment="Center"
+                                               Margin="2,0,0,0" />
+                                    <Border Style="{StaticResource CountBadgeStyle}">
+                                        <TextBlock Text="{Binding AvailableCount}"
+                                                   Foreground="White"
+                                                   FontFamily="Segoe UI" FontSize="10"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center" />
+                                    </Border>
+                                </DockPanel>
+                            </Border>
+
+                            <!-- Available items list -->
+                            <ItemsControl ItemsSource="{Binding AvailablePlugins}"
+                                          Visibility="{Binding IsAvailableExpanded, Converter={StaticResource BoolToVis}}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type vm:PluginItemViewModel}">
+                                        <Border Style="{StaticResource PluginItemBorderStyle}"
+                                                MouseLeftButtonDown="OnPluginItemClick"
+                                                Cursor="Hand">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="36" />
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+
+                                                <!-- Plugin icon -->
+                                                <Border Grid.Column="0" Width="32" Height="32"
+                                                        CornerRadius="4" Background="#2a2a2a"
+                                                        VerticalAlignment="Top" Margin="0,2,0,0">
+                                                    <Path Data="M 6,2 L 6,14 L 14,14 L 14,6 L 10,2 Z"
+                                                          Stroke="{DynamicResource SecondaryForegroundBrush}"
+                                                          StrokeThickness="1" Fill="Transparent"
+                                                          Stretch="Uniform" Width="16" Height="16"
+                                                          HorizontalAlignment="Center"
+                                                          VerticalAlignment="Center" />
+                                                </Border>
+
+                                                <!-- Title, description, publisher -->
+                                                <StackPanel Grid.Column="1" Margin="4,0,4,0">
+                                                    <TextBlock Text="{Binding DisplayName}"
+                                                               Foreground="{DynamicResource PrimaryForegroundBrush}"
+                                                               FontFamily="Segoe UI" FontSize="13"
+                                                               FontWeight="Bold"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding Description}"
+                                                               Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                                               FontFamily="Segoe UI" FontSize="11.5"
+                                                               TextTrimming="CharacterEllipsis"
+                                                               Margin="0,1,0,0" />
+                                                    <StackPanel Orientation="Horizontal" Margin="0,2,0,0">
+                                                        <TextBlock Text="{Binding Publisher}"
+                                                                   Foreground="{DynamicResource SecondaryForegroundBrush}"
+                                                                   FontFamily="Segoe UI" FontSize="10.5" />
+                                                        <!-- Verified badge (official only) -->
+                                                        <Canvas Width="14" Height="14" Margin="4,0,0,0"
+                                                                VerticalAlignment="Center"
+                                                                Visibility="{Binding IsOfficial, Converter={StaticResource BoolToVis}}">
+                                                            <Ellipse Width="14" Height="14"
+                                                                     Fill="{DynamicResource AccentBrush}" />
+                                                            <Path Data="M 3.5,7 L 6,9.5 L 10.5,5"
+                                                                  Stroke="#1e1e1e" StrokeThickness="1.5"
+                                                                  StrokeLineJoin="Round" Fill="Transparent"
+                                                                  Canvas.Left="0" Canvas.Top="0" />
+                                                        </Canvas>
+                                                    </StackPanel>
+                                                </StackPanel>
+
+                                                <!-- Install button -->
+                                                <Button Grid.Column="2"
+                                                        Style="{StaticResource InstallButtonStyle}"
+                                                        Content="Install"
+                                                        Click="OnInstallClick"
+                                                        VerticalAlignment="Bottom"
+                                                        Margin="0,0,0,2"
+                                                        ToolTip="Install plugin" />
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </DockPanel>
+                    </Border>
+                </StackPanel>
+            </ScrollViewer>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/src/Vido.Views/Panels/PluginManagerPanel.xaml.cs
+++ b/src/Vido.Views/Panels/PluginManagerPanel.xaml.cs
@@ -1,0 +1,116 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using Vido.ViewModels;
+
+namespace Vido.Views.Panels;
+
+/// <summary>
+/// Code-behind for the Plugin Manager sidebar panel.
+/// Handles click events and delegates to the PluginManagerViewModel.
+/// </summary>
+public partial class PluginManagerPanel : UserControl
+{
+    public PluginManagerPanel()
+    {
+        InitializeComponent();
+    }
+
+    /// <summary>
+    /// Toggles the Installed section expanded/collapsed state.
+    /// </summary>
+    private void OnInstalledHeaderClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is PluginManagerViewModel vm)
+            vm.IsInstalledExpanded = !vm.IsInstalledExpanded;
+    }
+
+    /// <summary>
+    /// Toggles the Available section expanded/collapsed state.
+    /// </summary>
+    private void OnAvailableHeaderClick(object sender, MouseButtonEventArgs e)
+    {
+        if (DataContext is PluginManagerViewModel vm)
+            vm.IsAvailableExpanded = !vm.IsAvailableExpanded;
+    }
+
+    /// <summary>
+    /// Opens the plugin detail panel when a plugin item is clicked.
+    /// </summary>
+    private void OnPluginItemClick(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is FrameworkElement fe && fe.DataContext is PluginItemViewModel item
+            && DataContext is PluginManagerViewModel vm)
+        {
+            vm.OpenDetailCommand.Execute(item);
+        }
+    }
+
+    /// <summary>
+    /// Opens the plugin settings when the cog icon is clicked.
+    /// </summary>
+    private void OnSettingsCogClick(object sender, RoutedEventArgs e)
+    {
+        e.Handled = true; // Prevent bubbling to OnPluginItemClick
+        if (sender is FrameworkElement fe && fe.DataContext is PluginItemViewModel item
+            && DataContext is PluginManagerViewModel vm)
+        {
+            vm.OpenPluginSettingsCommand.Execute(item);
+        }
+    }
+
+    /// <summary>
+    /// Installs a plugin when the Install button is clicked.
+    /// </summary>
+    private async void OnInstallClick(object sender, RoutedEventArgs e)
+    {
+        e.Handled = true; // Prevent bubbling to OnPluginItemClick
+        if (sender is FrameworkElement fe && fe.DataContext is PluginItemViewModel item
+            && DataContext is PluginManagerViewModel vm)
+        {
+            await vm.InstallPluginAsync(item);
+        }
+    }
+
+    /// <summary>
+    /// Uninstalls a plugin when the Uninstall button is clicked.
+    /// </summary>
+    private async void OnUninstallClick(object sender, RoutedEventArgs e)
+    {
+        e.Handled = true; // Prevent bubbling to OnPluginItemClick
+        if (sender is FrameworkElement fe && fe.DataContext is PluginItemViewModel item
+            && DataContext is PluginManagerViewModel vm)
+        {
+            await vm.UninstallPluginAsync(item);
+        }
+    }
+
+    // ── Focus highlight helpers ──
+
+    private static readonly SolidColorBrush FocusBrush = new(Color.FromRgb(0x00, 0x7a, 0xcc));
+
+    private void OnSearchBoxGotFocus(object sender, RoutedEventArgs e)
+        => SearchBorder.BorderBrush = FocusBrush;
+
+    private void OnSearchBoxLostFocus(object sender, RoutedEventArgs e)
+        => SearchBorder.BorderBrush = (Brush)FindResource("PrimaryBorderBrush");
+
+    private void OnDropdownGotFocus(object sender, RoutedEventArgs e)
+        => DropdownBorder.BorderBrush = FocusBrush;
+
+    private void OnDropdownLostFocus(object sender, RoutedEventArgs e)
+    {
+        if (!RegistryDropdown.IsDropDownOpen)
+            DropdownBorder.BorderBrush = (Brush)FindResource("PrimaryBorderBrush");
+    }
+
+    private void OnDropdownOpened(object sender, EventArgs e)
+        => DropdownBorder.BorderBrush = FocusBrush;
+
+    private void OnDropdownClosed(object sender, EventArgs e)
+    {
+        if (!RegistryDropdown.IsFocused)
+            DropdownBorder.BorderBrush = (Brush)FindResource("PrimaryBorderBrush");
+    }
+}

--- a/tests/Vido.Tests/PluginManagerTests.cs
+++ b/tests/Vido.Tests/PluginManagerTests.cs
@@ -1,0 +1,1703 @@
+using System.Text.Json;
+using NSubstitute;
+using Vido.Core.Logging;
+using Vido.Core.Plugin;
+using Vido.Core.Settings;
+using Vido.ViewModels;
+using Xunit;
+
+namespace Vido.Tests;
+
+/// <summary>
+/// Comprehensive unit tests for vi-019: Plugin Manager UI, Sample Plugin &amp;
+/// End-to-End Validation. Covers PluginManagerViewModel, PluginItemViewModel,
+/// SettingDisplayItem, PluginInstaller, and sample plugin manifest validation.
+/// </summary>
+public sealed class PluginManagerTests
+{
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ Helpers                                                        ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    private static PluginRegistryEntry MakeEntry(
+        string id = "com.test.plugin",
+        string displayName = "Test Plugin",
+        string author = "Tester",
+        string version = "1.0.0",
+        string registryName = "TestRegistry",
+        string registryUrl = "https://example.com/registry",
+        bool isOfficial = false)
+    {
+        return new PluginRegistryEntry
+        {
+            Id = id,
+            DisplayName = displayName,
+            Description = $"Description of {displayName}",
+            Author = author,
+            Version = version,
+            License = "MIT",
+            Tags = ["test", "sample"],
+            DownloadUrl = $"https://example.com/{id}.zip",
+            Repository = "https://github.com/test/plugin",
+            LastUpdated = "2025-01-15",
+            RegistryName = registryName,
+            RegistryUrl = registryUrl,
+            IsOfficial = isOfficial
+        };
+    }
+
+    private static PluginInfo MakePluginInfo(
+        string id = "com.test.plugin",
+        string displayName = "Test Plugin",
+        string author = "Tester",
+        PluginState state = PluginState.Active)
+    {
+        return new PluginInfo
+        {
+            Manifest = new PluginManifest
+            {
+                Id = id,
+                DisplayName = displayName,
+                Description = $"Description of {displayName}",
+                Author = author,
+                Version = "1.0.0",
+                License = "MIT",
+                Tags = ["test"],
+            },
+            Directory = $"C:\\plugins\\{id}",
+            State = state
+        };
+    }
+
+    private static (IPluginHost host, IPluginInstaller installer, ISettingsService settings, ILogService log) CreateMocks()
+    {
+        var host = Substitute.For<IPluginHost>();
+        var installer = Substitute.For<IPluginInstaller>();
+        var settings = Substitute.For<ISettingsService>();
+        var log = Substitute.For<ILogService>();
+        settings.Current.Returns(new AppSettings());
+        host.Plugins.Returns(Array.Empty<PluginInfo>());
+        return (host, installer, settings, log);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ PluginItemViewModel Tests                                      ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public void FromRegistryEntry_SetsAllProperties()
+    {
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+
+        Assert.Equal("com.test.plugin", item.Id);
+        Assert.Equal("Test Plugin", item.DisplayName);
+        Assert.Equal("Tester", item.Publisher);
+        Assert.Equal("1.0.0", item.Version);
+        Assert.Equal("MIT", item.License);
+        Assert.False(item.IsInstalled);
+        Assert.True(item.IsEnabled); // default
+        Assert.Same(entry, item.RegistryEntry);
+    }
+
+    [Fact]
+    public void FromRegistryEntry_Available_ShowsInstallButton()
+    {
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry());
+
+        Assert.True(item.ShowInstallButton);
+        Assert.False(item.ShowUninstallButton);
+        Assert.False(item.ShowSettingsCog);
+        Assert.False(item.ShowEnableDisableToggle);
+    }
+
+    [Fact]
+    public void FromPluginInfo_SetsInstalledProperties()
+    {
+        var info = MakePluginInfo();
+        var item = PluginItemViewModel.FromPluginInfo(info);
+
+        Assert.Equal("com.test.plugin", item.Id);
+        Assert.Equal("Test Plugin", item.DisplayName);
+        Assert.True(item.IsInstalled);
+        Assert.True(item.IsEnabled);
+        Assert.Same(info, item.PluginInfo);
+    }
+
+    [Fact]
+    public void FromPluginInfo_Disabled_SetsIsEnabledFalse()
+    {
+        var info = MakePluginInfo(state: PluginState.Disabled);
+        var item = PluginItemViewModel.FromPluginInfo(info);
+
+        Assert.True(item.IsInstalled);
+        Assert.False(item.IsEnabled);
+    }
+
+    [Fact]
+    public void FromPluginInfo_Error_SetsIsEnabledFalse()
+    {
+        var info = MakePluginInfo(state: PluginState.Error);
+        var item = PluginItemViewModel.FromPluginInfo(info);
+
+        Assert.False(item.IsEnabled);
+    }
+
+    [Fact]
+    public void Installed_ShowsCorrectButtons()
+    {
+        var item = PluginItemViewModel.FromPluginInfo(MakePluginInfo());
+
+        Assert.False(item.ShowInstallButton);
+        Assert.True(item.ShowUninstallButton);
+        Assert.True(item.ShowSettingsCog);
+        Assert.True(item.ShowEnableDisableToggle);
+    }
+
+    [Fact]
+    public void StatusText_Installed_Enabled()
+    {
+        var item = PluginItemViewModel.FromPluginInfo(MakePluginInfo());
+        Assert.Equal("Enabled", item.StatusText);
+    }
+
+    [Fact]
+    public void StatusText_Installed_Disabled()
+    {
+        var item = PluginItemViewModel.FromPluginInfo(MakePluginInfo(state: PluginState.Disabled));
+        Assert.Equal("Disabled", item.StatusText);
+    }
+
+    [Fact]
+    public void StatusText_Available_Empty()
+    {
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry());
+        Assert.Equal(string.Empty, item.StatusText);
+    }
+
+    [Fact]
+    public void IsInstalled_ChangeNotifiesComputedProperties()
+    {
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry());
+        var changedProps = new List<string>();
+        item.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName!);
+
+        item.IsInstalled = true;
+
+        Assert.Contains(nameof(item.StatusText), changedProps);
+        Assert.Contains(nameof(item.ShowInstallButton), changedProps);
+        Assert.Contains(nameof(item.ShowUninstallButton), changedProps);
+        Assert.Contains(nameof(item.ShowSettingsCog), changedProps);
+        Assert.Contains(nameof(item.ShowEnableDisableToggle), changedProps);
+    }
+
+    [Fact]
+    public void IsEnabled_ChangeNotifiesStatusText()
+    {
+        var item = PluginItemViewModel.FromPluginInfo(MakePluginInfo());
+        var changedProps = new List<string>();
+        item.PropertyChanged += (_, e) => changedProps.Add(e.PropertyName!);
+
+        item.IsEnabled = false;
+
+        Assert.Contains(nameof(item.StatusText), changedProps);
+    }
+
+    [Fact]
+    public void MatchesSearch_EmptyQuery_ReturnsTrue()
+    {
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry());
+        Assert.True(item.MatchesSearch(""));
+        Assert.True(item.MatchesSearch(null!));
+        Assert.True(item.MatchesSearch("   "));
+    }
+
+    [Fact]
+    public void MatchesSearch_MatchesDisplayName()
+    {
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry(displayName: "Video Effects"));
+        Assert.True(item.MatchesSearch("video"));
+        Assert.True(item.MatchesSearch("EFFECTS"));
+        Assert.False(item.MatchesSearch("audio"));
+    }
+
+    [Fact]
+    public void MatchesSearch_MatchesTags()
+    {
+        var entry = MakeEntry();
+        entry.Tags = ["video", "effects"];
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+
+        Assert.True(item.MatchesSearch("effects"));
+        Assert.False(item.MatchesSearch("audio"));
+    }
+
+    [Fact]
+    public void FromRegistryEntry_OfficialRegistry_SetsIsOfficial()
+    {
+        var entry = MakeEntry(isOfficial: true);
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+        Assert.True(item.IsOfficial);
+    }
+
+    [Fact]
+    public void FromRegistryEntry_UnofficialRegistry_IsOfficialFalse()
+    {
+        var entry = MakeEntry(isOfficial: false);
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+        Assert.False(item.IsOfficial);
+    }
+
+    [Fact]
+    public void FromRegistryEntry_NullEntry_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => PluginItemViewModel.FromRegistryEntry(null!));
+    }
+
+    [Fact]
+    public void FromPluginInfo_NullInfo_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => PluginItemViewModel.FromPluginInfo(null!));
+    }
+
+    [Fact]
+    public void DisplayName_FallsBackToId_WhenBlank()
+    {
+        var entry = MakeEntry(displayName: "");
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+        Assert.Equal(entry.Id, item.DisplayName);
+    }
+
+    [Fact]
+    public void FromPluginInfo_WithRegistryEntry_MergesData()
+    {
+        var info = MakePluginInfo();
+        var entry = MakeEntry(isOfficial: true);
+        var item = PluginItemViewModel.FromPluginInfo(info, entry);
+
+        Assert.True(item.IsOfficial);
+        Assert.Same(entry, item.RegistryEntry);
+        Assert.Equal(entry.DownloadUrl, item.DownloadUrl);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ PluginManagerViewModel Tests                                    ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public async Task LoadAsync_PopulatesInstalledFromHost()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var info = MakePluginInfo();
+        host.Plugins.Returns(new[] { info });
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(null));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Single(vm.InstalledPlugins);
+        Assert.Equal("com.test.plugin", vm.InstalledPlugins[0].Id);
+        Assert.Equal(1, vm.InstalledCount);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesAvailableFromRegistry()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var registry = new PluginRegistry
+        {
+            Name = "My Registry",
+            Plugins = [MakeEntry()]
+        };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Single(vm.AvailablePlugins);
+        Assert.Equal("com.test.plugin", vm.AvailablePlugins[0].Id);
+        Assert.Equal(1, vm.AvailableCount);
+        Assert.Empty(vm.InstalledPlugins);
+    }
+
+    [Fact]
+    public async Task LoadAsync_MergesInstalledWithRegistry()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var info = MakePluginInfo(id: "com.test.alpha");
+        host.Plugins.Returns(new[] { info });
+
+        var registry = new PluginRegistry
+        {
+            Name = "Reg",
+            Plugins = [MakeEntry(id: "com.test.alpha", isOfficial: true)]
+        };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Single(vm.InstalledPlugins);
+        Assert.Empty(vm.AvailablePlugins);
+        Assert.True(vm.InstalledPlugins[0].IsOfficial);
+    }
+
+    [Fact]
+    public async Task LoadAsync_DeduplicatesAcrossRegistries()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var appSettings = new AppSettings();
+        appSettings.PluginRegistryUrls.Add("https://extra.registry.com");
+        settings.Current.Returns(appSettings);
+
+        var pluginEntry = MakeEntry(id: "com.test.shared");
+
+        var registry1 = new PluginRegistry { Name = "Registry1", Plugins = [pluginEntry] };
+        var registry2 = new PluginRegistry { Name = "Registry2", Plugins = [MakeEntry(id: "com.test.shared")] };
+
+        // First call returns registry1, second returns registry2
+        installer.FetchRegistryAsync(appSettings.PluginRegistryUrls[0]).Returns(Task.FromResult<PluginRegistry?>(registry1));
+        installer.FetchRegistryAsync("https://extra.registry.com").Returns(Task.FromResult<PluginRegistry?>(registry2));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        // Should appear only once (first registry wins)
+        Assert.Single(vm.AvailablePlugins);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SetsRegistrySourceDropdown()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var registry = new PluginRegistry { Name = "My Registry", Plugins = [] };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Contains("All", vm.RegistrySources);
+        Assert.Contains("My Registry", vm.RegistrySources);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SetsIsLoadingDuringExecution()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var tcs = new TaskCompletionSource<PluginRegistry?>();
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(tcs.Task);
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        var loadTask = vm.LoadAsync();
+
+        Assert.True(vm.IsLoading);
+
+        tcs.SetResult(null);
+        await loadTask;
+
+        Assert.False(vm.IsLoading);
+    }
+
+    [Fact]
+    public async Task LoadAsync_HandlesRegistryFetchError()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(null));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync(); // Should not throw
+
+        Assert.Empty(vm.AvailablePlugins);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PreventsConcurrentExecution()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var callCount = 0;
+        var tcs = new TaskCompletionSource<PluginRegistry?>();
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(_ =>
+        {
+            Interlocked.Increment(ref callCount);
+            return tcs.Task;
+        });
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+
+        // First call starts (IsLoading = true); second should bail
+        var t1 = vm.LoadAsync();
+        var t2 = vm.LoadAsync(); // Should bail because IsLoading is true
+
+        tcs.SetResult(null); // Release the first call
+        await Task.WhenAll(t1, t2);
+
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task SearchQuery_FiltersPlugins()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var registry = new PluginRegistry
+        {
+            Name = "R",
+            Plugins =
+            [
+                MakeEntry(id: "alpha", displayName: "Alpha Plugin"),
+                MakeEntry(id: "beta", displayName: "Beta Plugin")
+            ]
+        };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.AvailablePlugins.Count);
+
+        vm.SearchQuery = "Alpha";
+        Assert.Single(vm.AvailablePlugins);
+        Assert.Equal("Alpha Plugin", vm.AvailablePlugins[0].DisplayName);
+    }
+
+    [Fact]
+    public async Task SearchQuery_ClearingResetsFilter()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entryX = MakeEntry(id: "x", displayName: "Xylophone");
+        entryX.Tags = ["unique-x"];
+        var entryY = MakeEntry(id: "y", displayName: "Yonder");
+        entryY.Tags = ["unique-y"];
+        var registry = new PluginRegistry
+        {
+            Name = "R",
+            Plugins = [entryX, entryY]
+        };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        vm.SearchQuery = "Xylophone";
+        Assert.Single(vm.AvailablePlugins);
+
+        vm.SearchQuery = "";
+        Assert.Equal(2, vm.AvailablePlugins.Count);
+    }
+
+    [Fact]
+    public async Task RegistrySourceFilter_FiltersAvailable()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+
+        var appSettings = new AppSettings();
+        appSettings.PluginRegistryUrls.Add("https://second.registry.com");
+        settings.Current.Returns(appSettings);
+
+        var r1 = new PluginRegistry { Name = "Registry1", Plugins = [MakeEntry(id: "r1-plugin", displayName: "R1 Plugin")] };
+        var r2 = new PluginRegistry { Name = "Registry2", Plugins = [MakeEntry(id: "r2-plugin", displayName: "R2 Plugin")] };
+
+        installer.FetchRegistryAsync(appSettings.PluginRegistryUrls[0]).Returns(Task.FromResult<PluginRegistry?>(r1));
+        installer.FetchRegistryAsync("https://second.registry.com").Returns(Task.FromResult<PluginRegistry?>(r2));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.AvailablePlugins.Count);
+
+        vm.SelectedRegistrySource = "Registry1";
+        Assert.Single(vm.AvailablePlugins);
+        Assert.Equal("R1 Plugin", vm.AvailablePlugins[0].DisplayName);
+    }
+
+    [Fact]
+    public async Task RegistrySourceFilter_InstalledPluginsAlwaysShown()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var info = MakePluginInfo(id: "installed-plugin");
+        host.Plugins.Returns(new[] { info });
+
+        var registry = new PluginRegistry { Name = "SomeReg", Plugins = [] };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        vm.SelectedRegistrySource = "SomeReg";
+        // Installed plugins without matching registry should still show
+        Assert.Single(vm.InstalledPlugins);
+    }
+
+    [Fact]
+    public async Task InstallPluginAsync_TransitionsItemToInstalled()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+
+        installer.InstallAsync(entry).Returns(Task.FromResult(true));
+        host.GetPlugin(entry.Id).Returns((PluginInfo?)null);
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+
+        await vm.InstallPluginAsync(item);
+
+        Assert.True(item.IsInstalled);
+        Assert.True(item.IsEnabled);
+        Assert.False(item.IsBusy);
+    }
+
+    [Fact]
+    public async Task InstallPluginAsync_FailedInstall_NoStateChange()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+
+        installer.InstallAsync(entry).Returns(Task.FromResult(false));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.InstallPluginAsync(item);
+
+        Assert.False(item.IsInstalled);
+    }
+
+    [Fact]
+    public async Task InstallPluginAsync_FiresOpenDetailRequested()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+        installer.InstallAsync(entry).Returns(Task.FromResult(true));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        PluginItemViewModel? requestedItem = null;
+        vm.OpenDetailRequested += i => requestedItem = i;
+
+        await vm.InstallPluginAsync(item);
+
+        Assert.Same(item, requestedItem);
+    }
+
+    [Fact]
+    public async Task InstallPluginAsync_SkipsIfAlreadyInstalled()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+        item.IsInstalled = true;
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.InstallPluginAsync(item);
+
+        await installer.DidNotReceive().InstallAsync(Arg.Any<PluginRegistryEntry>());
+    }
+
+    [Fact]
+    public async Task InstallPluginAsync_SkipsIfBusy()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+        item.IsBusy = true;
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.InstallPluginAsync(item);
+
+        await installer.DidNotReceive().InstallAsync(Arg.Any<PluginRegistryEntry>());
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_TransitionsItemToAvailable()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var info = MakePluginInfo();
+        var item = PluginItemViewModel.FromPluginInfo(info);
+
+        installer.UninstallAsync(item.Id).Returns(Task.FromResult(true));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.UninstallPluginAsync(item);
+
+        Assert.False(item.IsInstalled);
+        Assert.False(item.IsEnabled);
+        Assert.Null(item.PluginInfo);
+        Assert.False(item.IsBusy);
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_SkipsIfNotInstalled()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry();
+        var item = PluginItemViewModel.FromRegistryEntry(entry);
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.UninstallPluginAsync(item);
+
+        await installer.DidNotReceive().UninstallAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task UninstallPluginAsync_DisablesPluginFirst()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var info = MakePluginInfo();
+        var item = PluginItemViewModel.FromPluginInfo(info);
+        installer.UninstallAsync(item.Id).Returns(Task.FromResult(true));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.UninstallPluginAsync(item);
+
+        host.Received(1).SetEnabled(item.Id, false);
+    }
+
+    [Fact]
+    public void ToggleEnabled_TogglesState()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var item = PluginItemViewModel.FromPluginInfo(MakePluginInfo());
+        Assert.True(item.IsEnabled);
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+
+        vm.ToggleEnabled(item);
+        Assert.False(item.IsEnabled);
+        host.Received(1).SetEnabled(item.Id, false);
+
+        vm.ToggleEnabled(item);
+        Assert.True(item.IsEnabled);
+        host.Received(1).SetEnabled(item.Id, true);
+    }
+
+    [Fact]
+    public void ToggleEnabled_IgnoresNonInstalled()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry());
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        vm.ToggleEnabled(item); // Should be a no-op
+
+        host.DidNotReceive().SetEnabled(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public void OpenDetail_FiresOpenDetailRequested()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var item = PluginItemViewModel.FromRegistryEntry(MakeEntry());
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        PluginItemViewModel? received = null;
+        vm.OpenDetailRequested += i => received = i;
+
+        vm.OpenDetail(item);
+
+        Assert.Same(item, received);
+    }
+
+    [Fact]
+    public void OpenPluginSettings_FiresOpenSettingsRequested()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var item = PluginItemViewModel.FromPluginInfo(MakePluginInfo());
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        PluginItemViewModel? received = null;
+        vm.OpenSettingsRequested += i => received = i;
+
+        vm.OpenPluginSettings(item);
+
+        Assert.Same(item, received);
+    }
+
+    [Fact]
+    public async Task CountBadges_UpdateOnFilterChanges()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        host.Plugins.Returns(new[] { MakePluginInfo(id: "inst1"), MakePluginInfo(id: "inst2") });
+
+        var registry = new PluginRegistry
+        {
+            Name = "R",
+            Plugins = [MakeEntry(id: "avail1")]
+        };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Equal(2, vm.InstalledCount);
+        Assert.Equal(1, vm.AvailableCount);
+
+        // Search that matches no plugins
+        vm.SearchQuery = "zzzzz";
+        Assert.Equal(0, vm.InstalledCount);
+        Assert.Equal(0, vm.AvailableCount);
+    }
+
+    [Fact]
+    public async Task LoadAsync_OfficialRegistryUrl_SetsOfficial()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry(id: "official-plugin");
+        var registry = new PluginRegistry { Name = "Vido Official", Plugins = [entry] };
+
+        installer.FetchRegistryAsync(AppSettings.OfficialRegistryUrl).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.True(vm.AvailablePlugins[0].IsOfficial);
+    }
+
+    [Fact]
+    public async Task LoadAsync_NonOfficialUrl_SetsOfficialFalse()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var appSettings = new AppSettings();
+        appSettings.PluginRegistryUrls.Clear();
+        appSettings.PluginRegistryUrls.Add("https://custom.example.com/registry");
+        settings.Current.Returns(appSettings);
+
+        var entry = MakeEntry(id: "custom-plugin");
+        var registry = new PluginRegistry { Name = "Custom", Plugins = [entry] };
+        installer.FetchRegistryAsync("https://custom.example.com/registry").Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.False(vm.AvailablePlugins[0].IsOfficial);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ SettingDisplayItem Tests                                        ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public void BooleanSetting_InitialisesFromStore()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("flag", Arg.Any<bool>()).Returns(true);
+
+        var def = new SettingContribution { Id = "flag", Type = "boolean", Default = true, Title = "Flag", Description = "A flag" };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.True(item.IsBoolean);
+        Assert.False(item.IsString);
+        Assert.False(item.IsNumber);
+        Assert.False(item.IsEnum);
+        Assert.Equal("True", item.SelectedBooleanValue);
+    }
+
+    [Fact]
+    public void BooleanSetting_DefaultFalse()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("flag", Arg.Any<bool>()).Returns(false);
+
+        var def = new SettingContribution { Id = "flag", Type = "boolean", Default = false };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.Equal("False", item.SelectedBooleanValue);
+    }
+
+    [Fact]
+    public void BooleanSetting_AutoSavesOnChange()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("flag", Arg.Any<bool>()).Returns(true);
+
+        var def = new SettingContribution { Id = "flag", Type = "boolean" };
+        var item = new SettingDisplayItem(def, store);
+
+        item.SelectedBooleanValue = "False";
+
+        store.Received(1).Set("flag", false);
+    }
+
+    [Fact]
+    public void BooleanSetting_DoesNotSaveDuringInitialization()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("flag", Arg.Any<bool>()).Returns(true);
+
+        var def = new SettingContribution { Id = "flag", Type = "boolean" };
+        _ = new SettingDisplayItem(def, store);
+
+        // Set is never called during construction
+        store.DidNotReceive().Set(Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public void StringSetting_InitialisesFromStore()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("name", Arg.Any<string>()).Returns("Hello");
+
+        var def = new SettingContribution { Id = "name", Type = "string", Default = "Default" };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.True(item.IsString);
+        Assert.Equal("Hello", item.StringValue);
+    }
+
+    [Fact]
+    public void StringSetting_AutoSavesOnChange()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("name", Arg.Any<string>()).Returns("Old");
+
+        var def = new SettingContribution { Id = "name", Type = "string" };
+        var item = new SettingDisplayItem(def, store);
+
+        item.StringValue = "New";
+
+        store.Received(1).Set("name", "New");
+    }
+
+    [Fact]
+    public void NumberSetting_InitialisesFromStore()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("interval", Arg.Any<double>()).Returns(30.0);
+
+        var def = new SettingContribution { Id = "interval", Type = "number", Default = 30.0 };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.True(item.IsNumber);
+        Assert.Equal("30", item.StringValue);
+    }
+
+    [Fact]
+    public void NumberSetting_AutoSavesOnChange()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("interval", Arg.Any<double>()).Returns(30.0);
+
+        var def = new SettingContribution { Id = "interval", Type = "number" };
+        var item = new SettingDisplayItem(def, store);
+
+        item.StringValue = "60";
+
+        store.Received(1).Set("interval", 60.0);
+    }
+
+    [Fact]
+    public void NumberSetting_InvalidString_DoesNotSave()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("interval", Arg.Any<double>()).Returns(30.0);
+
+        var def = new SettingContribution { Id = "interval", Type = "number" };
+        var item = new SettingDisplayItem(def, store);
+
+        item.StringValue = "abc";
+
+        store.DidNotReceive().Set("interval", Arg.Any<double>());
+    }
+
+    [Fact]
+    public void EnumSetting_InitialisesFromStore()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("level", Arg.Any<string>()).Returns("Warning");
+
+        var def = new SettingContribution
+        {
+            Id = "level",
+            Type = "enum",
+            Default = "Info",
+            EnumValues = ["Debug", "Info", "Warning", "Error"]
+        };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.True(item.IsEnum);
+        Assert.Equal("Warning", item.SelectedEnumValue);
+        Assert.Equal(4, item.EnumValues.Count);
+    }
+
+    [Fact]
+    public void EnumSetting_AutoSavesOnChange()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("level", Arg.Any<string>()).Returns("Info");
+
+        var def = new SettingContribution
+        {
+            Id = "level",
+            Type = "enum",
+            Default = "Info",
+            EnumValues = ["Debug", "Info", "Warning", "Error"]
+        };
+        var item = new SettingDisplayItem(def, store);
+
+        item.SelectedEnumValue = "Debug";
+
+        store.Received(1).Set("level", "Debug");
+    }
+
+    [Fact]
+    public void EnumSetting_EmptyValue_DoesNotSave()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("level", Arg.Any<string>()).Returns("Info");
+
+        var def = new SettingContribution
+        {
+            Id = "level",
+            Type = "enum",
+            EnumValues = ["Debug", "Info"]
+        };
+        var item = new SettingDisplayItem(def, store);
+
+        item.SelectedEnumValue = "";
+
+        store.DidNotReceive().Set("level", "");
+    }
+
+    [Fact]
+    public void SectionProperty_ReturnsManifestSection()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("x", Arg.Any<string>()).Returns("v");
+        var def = new SettingContribution { Id = "x", Type = "string", Section = "Display" };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.Equal("Display", item.Section);
+    }
+
+    [Fact]
+    public void BooleanOptions_ContainsTrueAndFalse()
+    {
+        Assert.Equal(2, SettingDisplayItem.BooleanOptions.Count);
+        Assert.Contains("True", SettingDisplayItem.BooleanOptions);
+        Assert.Contains("False", SettingDisplayItem.BooleanOptions);
+    }
+
+    [Fact]
+    public void Constructor_NullDefinition_Throws()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        Assert.Throws<ArgumentNullException>(() => new SettingDisplayItem(null!, store));
+    }
+
+    [Fact]
+    public void Constructor_NullStore_Throws()
+    {
+        var def = new SettingContribution { Id = "x", Type = "string" };
+        Assert.Throws<ArgumentNullException>(() => new SettingDisplayItem(def, null!));
+    }
+
+    [Fact]
+    public void ConvertDefault_HandlesJsonElement_Boolean()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        var json = JsonSerializer.Deserialize<JsonElement>("true");
+        store.Get("b", Arg.Any<bool>()).Returns(true);
+
+        var def = new SettingContribution { Id = "b", Type = "boolean", Default = json };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.Equal("True", item.SelectedBooleanValue);
+    }
+
+    [Fact]
+    public void ConvertDefault_HandlesJsonElement_Number()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        var json = JsonSerializer.Deserialize<JsonElement>("42");
+        store.Get("n", Arg.Any<double>()).Returns(42.0);
+
+        var def = new SettingContribution { Id = "n", Type = "number", Default = json };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.Equal("42", item.StringValue);
+    }
+
+    [Fact]
+    public void ConvertDefault_HandlesJsonElement_String()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        var json = JsonSerializer.Deserialize<JsonElement>("\"hello\"");
+        store.Get("s", Arg.Any<string>()).Returns("hello");
+
+        var def = new SettingContribution { Id = "s", Type = "string", Default = json };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.Equal("hello", item.StringValue);
+    }
+
+    [Fact]
+    public void TitleAndDescription_ReturnFromDefinition()
+    {
+        var store = Substitute.For<IPluginSettingsStore>();
+        store.Get("x", Arg.Any<string>()).Returns("v");
+        var def = new SettingContribution { Id = "x", Type = "string", Title = "My Title", Description = "My Desc" };
+        var item = new SettingDisplayItem(def, store);
+
+        Assert.Equal("My Title", item.Title);
+        Assert.Equal("My Desc", item.Description);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ PluginInstaller Tests (file-system integration)                 ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public async Task InstallAsync_NullEntry_Throws()
+    {
+        var log = Substitute.For<ILogService>();
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+        await Assert.ThrowsAsync<ArgumentNullException>(() => installer.InstallAsync(null!));
+    }
+
+    [Fact]
+    public async Task InstallAsync_EmptyId_Throws()
+    {
+        var log = Substitute.For<ILogService>();
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+        var entry = new PluginRegistryEntry { Id = "", DownloadUrl = "http://example.com/p.zip" };
+        await Assert.ThrowsAsync<ArgumentException>(() => installer.InstallAsync(entry));
+    }
+
+    [Fact]
+    public async Task InstallAsync_EmptyDownloadUrl_Throws()
+    {
+        var log = Substitute.For<ILogService>();
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+        var entry = new PluginRegistryEntry { Id = "test", DownloadUrl = "" };
+        await Assert.ThrowsAsync<ArgumentException>(() => installer.InstallAsync(entry));
+    }
+
+    [Fact]
+    public async Task UninstallAsync_EmptyId_Throws()
+    {
+        var log = Substitute.For<ILogService>();
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+        await Assert.ThrowsAsync<ArgumentException>(() => installer.UninstallAsync(""));
+    }
+
+    [Fact]
+    public async Task UninstallAsync_NonexistentDir_ReturnsTrue()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), tempDir);
+
+        var result = await installer.UninstallAsync("nonexistent-plugin");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task UninstallAsync_ExistingDir_DeletesIt()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vido-test-{Guid.NewGuid()}");
+        var pluginDir = Path.Combine(tempDir, "test-plugin");
+        Directory.CreateDirectory(pluginDir);
+        File.WriteAllText(Path.Combine(pluginDir, "plugin.json"), "{}");
+
+        try
+        {
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), tempDir);
+            var result = await installer.UninstallAsync("test-plugin");
+
+            Assert.True(result);
+            Assert.False(Directory.Exists(pluginDir));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CleanupPendingUninstalls_RemovesMarkedDirectories()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vido-test-{Guid.NewGuid()}");
+        var markedDir = Path.Combine(tempDir, "marked-plugin");
+        var cleanDir = Path.Combine(tempDir, "clean-plugin");
+
+        Directory.CreateDirectory(markedDir);
+        Directory.CreateDirectory(cleanDir);
+        File.WriteAllText(Path.Combine(markedDir, ".uninstall"), DateTime.UtcNow.ToString("O"));
+        File.WriteAllText(Path.Combine(cleanDir, "plugin.json"), "{}");
+
+        try
+        {
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), tempDir);
+            installer.CleanupPendingUninstalls();
+
+            Assert.False(Directory.Exists(markedDir));
+            Assert.True(Directory.Exists(cleanDir));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CleanupPendingUninstalls_NonexistentBaseDir_NoOp()
+    {
+        var log = Substitute.For<ILogService>();
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), @"C:\nonexistent\path\" + Guid.NewGuid());
+        installer.CleanupPendingUninstalls(); // Should not throw
+    }
+
+    [Fact]
+    public async Task FetchRegistryAsync_EmptyUrl_ReturnsNull()
+    {
+        var log = Substitute.For<ILogService>();
+        var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+
+        var result = await installer.FetchRegistryAsync("");
+        Assert.Null(result);
+
+        result = await installer.FetchRegistryAsync(null!);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FetchRegistryAsync_FileUrl_ParsesJson()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempFile = Path.GetTempFileName();
+        var registryJson = """
+        {
+            "name": "Test Registry",
+            "plugins": [
+                {
+                    "id": "com.test.plugin",
+                    "displayName": "Test",
+                    "description": "Desc",
+                    "author": "Author",
+                    "version": "1.0.0",
+                    "license": "MIT",
+                    "tags": ["test"],
+                    "downloadUrl": "https://example.com/test.zip"
+                }
+            ]
+        }
+        """;
+        File.WriteAllText(tempFile, registryJson);
+
+        try
+        {
+            var fileUrl = new Uri(tempFile).ToString();
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+            var registry = await installer.FetchRegistryAsync(fileUrl);
+
+            Assert.NotNull(registry);
+            Assert.Equal("Test Registry", registry!.Name);
+            Assert.Single(registry.Plugins);
+            Assert.Equal("com.test.plugin", registry.Plugins[0].Id);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task FetchRegistryAsync_InvalidJson_ReturnsNull()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "NOT JSON");
+
+        try
+        {
+            var fileUrl = new Uri(tempFile).ToString();
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), Path.GetTempPath());
+            var registry = await installer.FetchRegistryAsync(fileUrl);
+
+            Assert.Null(registry);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task InstallAsync_FileUrl_ExtractsAndValidates()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vido-install-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        // Create a valid plugin zip
+        var zipPath = Path.Combine(tempDir, "test-plugin.zip");
+        var stageDir = Path.Combine(tempDir, "stage");
+        Directory.CreateDirectory(stageDir);
+        File.WriteAllText(Path.Combine(stageDir, "plugin.json"), """{"id":"test-plugin","name":"test"}""");
+        File.WriteAllText(Path.Combine(stageDir, "test.dll"), "fake-dll");
+        System.IO.Compression.ZipFile.CreateFromDirectory(stageDir, zipPath);
+
+        var pluginsDir = Path.Combine(tempDir, "plugins");
+
+        try
+        {
+            var fileUrl = new Uri(zipPath).ToString();
+            var entry = new PluginRegistryEntry
+            {
+                Id = "test-plugin",
+                DownloadUrl = fileUrl,
+                DisplayName = "Test"
+            };
+
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), pluginsDir);
+            var result = await installer.InstallAsync(entry);
+
+            Assert.True(result);
+            Assert.True(File.Exists(Path.Combine(pluginsDir, "test-plugin", "plugin.json")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task InstallAsync_ZipWithRootFolder_MovesContentsUp()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vido-root-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        // Create zip with single root folder wrapping plugin files
+        var zipPath = Path.Combine(tempDir, "wrapped.zip");
+        var stageDir = Path.Combine(tempDir, "stage", "inner-folder");
+        Directory.CreateDirectory(stageDir);
+        File.WriteAllText(Path.Combine(stageDir, "plugin.json"), """{"id":"wrapped","name":"wrapped"}""");
+        System.IO.Compression.ZipFile.CreateFromDirectory(Path.Combine(tempDir, "stage"), zipPath);
+
+        var pluginsDir = Path.Combine(tempDir, "plugins");
+
+        try
+        {
+            var entry = new PluginRegistryEntry
+            {
+                Id = "wrapped",
+                DownloadUrl = new Uri(zipPath).ToString(),
+                DisplayName = "Wrapped"
+            };
+
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), pluginsDir);
+            var result = await installer.InstallAsync(entry);
+
+            Assert.True(result);
+            Assert.True(File.Exists(Path.Combine(pluginsDir, "wrapped", "plugin.json")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task InstallAsync_ZipWithoutManifest_ReturnsFalse()
+    {
+        var log = Substitute.For<ILogService>();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vido-nomanifest-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+
+        // Create zip with no plugin.json
+        var zipPath = Path.Combine(tempDir, "bad.zip");
+        var stageDir = Path.Combine(tempDir, "stage");
+        Directory.CreateDirectory(stageDir);
+        File.WriteAllText(Path.Combine(stageDir, "readme.txt"), "no manifest here");
+        System.IO.Compression.ZipFile.CreateFromDirectory(stageDir, zipPath);
+
+        var pluginsDir = Path.Combine(tempDir, "plugins");
+
+        try
+        {
+            var entry = new PluginRegistryEntry
+            {
+                Id = "bad-plugin",
+                DownloadUrl = new Uri(zipPath).ToString(),
+                DisplayName = "Bad"
+            };
+
+            var installer = new Vido.Services.Plugin.PluginInstaller(log, new HttpClient(), pluginsDir);
+            var result = await installer.InstallAsync(entry);
+
+            Assert.False(result);
+            Assert.False(Directory.Exists(Path.Combine(pluginsDir, "bad-plugin")));
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ PluginRegistryEntry Tests                                      ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public void PluginRegistryEntry_DefaultValues()
+    {
+        var entry = new PluginRegistryEntry();
+
+        Assert.Equal(string.Empty, entry.Id);
+        Assert.Equal(string.Empty, entry.DisplayName);
+        Assert.Equal(string.Empty, entry.Description);
+        Assert.Equal(string.Empty, entry.Author);
+        Assert.Equal(string.Empty, entry.Version);
+        Assert.Equal(string.Empty, entry.License);
+        Assert.Empty(entry.Tags);
+        Assert.Equal(string.Empty, entry.DownloadUrl);
+        Assert.Null(entry.IconUrl);
+        Assert.Null(entry.Repository);
+        Assert.Null(entry.LastUpdated);
+        Assert.Equal(string.Empty, entry.RegistryUrl);
+        Assert.Equal(string.Empty, entry.RegistryName);
+        Assert.False(entry.IsOfficial);
+    }
+
+    [Fact]
+    public void PluginRegistry_DefaultValues()
+    {
+        var registry = new PluginRegistry();
+
+        Assert.Equal(string.Empty, registry.Name);
+        Assert.Empty(registry.Plugins);
+    }
+
+    [Fact]
+    public void PluginRegistryEntry_JsonRoundTrip()
+    {
+        var entry = MakeEntry();
+        var json = JsonSerializer.Serialize(entry);
+        var roundTripped = JsonSerializer.Deserialize<PluginRegistryEntry>(json)!;
+
+        Assert.Equal(entry.Id, roundTripped.Id);
+        Assert.Equal(entry.DisplayName, roundTripped.DisplayName);
+        Assert.Equal(entry.Version, roundTripped.Version);
+        // JsonIgnore properties should not be serialized
+        Assert.Equal(string.Empty, roundTripped.RegistryUrl);
+        Assert.Equal(string.Empty, roundTripped.RegistryName);
+        Assert.False(roundTripped.IsOfficial);
+    }
+
+    [Fact]
+    public void PluginRegistry_JsonRoundTrip()
+    {
+        var registry = new PluginRegistry
+        {
+            Name = "Test Registry",
+            Plugins = [MakeEntry(id: "p1"), MakeEntry(id: "p2")]
+        };
+        var json = JsonSerializer.Serialize(registry);
+        var roundTripped = JsonSerializer.Deserialize<PluginRegistry>(json)!;
+
+        Assert.Equal("Test Registry", roundTripped.Name);
+        Assert.Equal(2, roundTripped.Plugins.Count);
+        Assert.Equal("p1", roundTripped.Plugins[0].Id);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ Sample Plugin Manifest Validation                               ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public void SamplePluginManifest_HasAllRequiredFields()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        Assert.Equal("com.vido.sample-plugin", manifest.Id);
+        Assert.Equal("vido-sample-plugin", manifest.Name);
+        Assert.Equal("Sample Plugin", manifest.DisplayName);
+        Assert.Equal("1.0.0", manifest.Version);
+        Assert.False(string.IsNullOrWhiteSpace(manifest.Description));
+        Assert.Equal("Vido Team", manifest.Author);
+        Assert.Equal("MIT", manifest.License);
+        Assert.Equal("Vido.SamplePlugin.dll", manifest.EntryPoint);
+        Assert.Equal("Vido.SamplePlugin.SamplePlugin", manifest.PluginClass);
+        Assert.False(string.IsNullOrWhiteSpace(manifest.MinVidoVersion));
+        Assert.NotEmpty(manifest.Tags);
+    }
+
+    [Fact]
+    public void SamplePluginManifest_DeclaresAllContributionTypes()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+        var c = manifest.Contributes;
+
+        Assert.NotEmpty(c.Sidebar);
+        Assert.NotEmpty(c.BottomPanel);
+        Assert.NotEmpty(c.RightPanel);
+        Assert.NotEmpty(c.StatusBar);
+        Assert.NotEmpty(c.ToolbarButtons);
+        Assert.NotEmpty(c.ContextMenu);
+        Assert.NotEmpty(c.FileHandlers);
+        Assert.NotEmpty(c.FileIcons);
+    }
+
+    [Fact]
+    public void SamplePluginManifest_DeclaresAllSettingTypes()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+        var settings = manifest.Contributes.Settings;
+
+        Assert.True(settings.Count >= 4, "Should have at least 4 settings");
+
+        var types = settings.Select(s => s.Type.ToLowerInvariant()).ToHashSet();
+        Assert.Contains("boolean", types);
+        Assert.Contains("string", types);
+        Assert.Contains("number", types);
+        Assert.Contains("enum", types);
+    }
+
+    [Fact]
+    public void SamplePluginManifest_HasAtLeastTwoSections()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        var sections = manifest.Contributes.Settings
+            .Where(s => !string.IsNullOrWhiteSpace(s.Section))
+            .Select(s => s.Section)
+            .Distinct()
+            .ToList();
+
+        Assert.True(sections.Count >= 2, $"Expected at least 2 sections, got {sections.Count}: {string.Join(", ", sections)}");
+    }
+
+    [Fact]
+    public void SamplePluginManifest_HasForceOverrideSetting()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        Assert.True(
+            manifest.Contributes.Settings.Any(s => s.ForceOverride),
+            "At least one setting must have forceOverride: true");
+    }
+
+    [Fact]
+    public void SamplePluginManifest_EnumSetting_HasEnumValues()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        var enumSettings = manifest.Contributes.Settings.Where(s => s.Type.Equals("enum", StringComparison.OrdinalIgnoreCase));
+        foreach (var setting in enumSettings)
+        {
+            Assert.NotEmpty(setting.EnumValues);
+        }
+    }
+
+    [Fact]
+    public void SamplePluginManifest_SidebarContribution_HasIdAndTitle()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        foreach (var sidebar in manifest.Contributes.Sidebar)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(sidebar.Id));
+            Assert.False(string.IsNullOrWhiteSpace(sidebar.Title));
+        }
+    }
+
+    [Fact]
+    public void SamplePluginManifest_FileHandler_HasSampleExtension()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        var extensions = manifest.Contributes.FileHandlers.SelectMany(h => h.Extensions).ToList();
+        Assert.Contains(".sample", extensions);
+    }
+
+    [Fact]
+    public void SamplePluginManifest_FileIcons_HasSampleExtension()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "plugin.json"));
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json)!;
+
+        Assert.True(manifest.Contributes.FileIcons.ContainsKey(".sample"));
+    }
+
+    [Fact]
+    public void SamplePlugin_ReadmeExists()
+    {
+        Assert.True(File.Exists(Path.Combine(GetSamplePluginPath(), "README.md")));
+    }
+
+    [Fact]
+    public void SamplePlugin_ChangelogExists()
+    {
+        Assert.True(File.Exists(Path.Combine(GetSamplePluginPath(), "CHANGELOG.md")));
+    }
+
+    [Fact]
+    public void SamplePlugin_RegistryJsonExists()
+    {
+        Assert.True(File.Exists(Path.Combine(GetSamplePluginPath(), "registry.json")));
+    }
+
+    [Fact]
+    public void SamplePlugin_RegistryJson_ContainsSamplePlugin()
+    {
+        var json = File.ReadAllText(Path.Combine(GetSamplePluginPath(), "registry.json"));
+        var registry = JsonSerializer.Deserialize<PluginRegistry>(json)!;
+
+        Assert.NotNull(registry);
+        Assert.NotEmpty(registry.Plugins);
+        Assert.Contains(registry.Plugins, p => p.Id == "com.vido.sample-plugin");
+    }
+
+    private static string GetSamplePluginPath()
+    {
+        // Navigate from the test project to the sample plugin directory
+        // Test project: c:\source\vido\tests\Vido.Tests
+        // Sample plugin: c:\source\vido-sample-plugin
+        var testDir = AppContext.BaseDirectory;
+        var solutionRoot = Path.GetFullPath(Path.Combine(testDir, "..", "..", "..", "..", ".."));
+        var samplePluginPath = Path.Combine(Path.GetDirectoryName(solutionRoot)!, "vido-sample-plugin");
+
+        if (!Directory.Exists(samplePluginPath))
+            throw new DirectoryNotFoundException($"Sample plugin not found at: {samplePluginPath}");
+
+        return samplePluginPath;
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ PluginPaths Tests                                               ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public void PluginPaths_DefaultPluginDirectory_IsNotEmpty()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(PluginPaths.DefaultPluginDirectory));
+    }
+
+    [Fact]
+    public void PluginPaths_DefaultPluginDirectory_EndsWithPlugins()
+    {
+        Assert.EndsWith("plugins", PluginPaths.DefaultPluginDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ Integration: PluginManagerViewModel end-to-end flows            ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    [Fact]
+    public async Task FullFlow_Install_ThenUninstall()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry(id: "flow-plugin", displayName: "Flow Plugin");
+        var registry = new PluginRegistry { Name = "R", Plugins = [entry] };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+        installer.InstallAsync(entry).Returns(Task.FromResult(true));
+        installer.UninstallAsync("flow-plugin").Returns(Task.FromResult(true));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        Assert.Single(vm.AvailablePlugins);
+        Assert.Empty(vm.InstalledPlugins);
+
+        // Install
+        var item = vm.AvailablePlugins[0];
+        await vm.InstallPluginAsync(item);
+
+        Assert.True(item.IsInstalled);
+        Assert.Single(vm.InstalledPlugins);
+        Assert.Empty(vm.AvailablePlugins);
+
+        // Uninstall
+        await vm.UninstallPluginAsync(item);
+
+        Assert.False(item.IsInstalled);
+        Assert.Empty(vm.InstalledPlugins);
+        Assert.Single(vm.AvailablePlugins);
+    }
+
+    [Fact]
+    public async Task FullFlow_Install_ToggleEnabled()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var entry = MakeEntry(id: "toggle-plugin");
+        var registry = new PluginRegistry { Name = "R", Plugins = [entry] };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+        installer.InstallAsync(entry).Returns(Task.FromResult(true));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        var item = vm.AvailablePlugins[0];
+        await vm.InstallPluginAsync(item);
+
+        Assert.True(item.IsEnabled);
+        Assert.Equal("Enabled", item.StatusText);
+
+        vm.ToggleEnabled(item);
+
+        Assert.False(item.IsEnabled);
+        Assert.Equal("Disabled", item.StatusText);
+
+        vm.ToggleEnabled(item);
+
+        Assert.True(item.IsEnabled);
+        Assert.Equal("Enabled", item.StatusText);
+    }
+
+    [Fact]
+    public async Task ExpandCollapse_Sections_AreIndependent()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+
+        Assert.True(vm.IsInstalledExpanded);
+        Assert.True(vm.IsAvailableExpanded);
+
+        vm.IsInstalledExpanded = false;
+        Assert.False(vm.IsInstalledExpanded);
+        Assert.True(vm.IsAvailableExpanded);
+
+        vm.IsAvailableExpanded = false;
+        Assert.False(vm.IsInstalledExpanded);
+        Assert.False(vm.IsAvailableExpanded);
+    }
+
+    [Fact]
+    public async Task SearchQuery_IsCaseInsensitive()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var registry = new PluginRegistry
+        {
+            Name = "R",
+            Plugins = [MakeEntry(id: "p1", displayName: "Video Editor")]
+        };
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        vm.SearchQuery = "VIDEO";
+        Assert.Single(vm.AvailablePlugins);
+
+        vm.SearchQuery = "video";
+        Assert.Single(vm.AvailablePlugins);
+
+        vm.SearchQuery = "ViDeO";
+        Assert.Single(vm.AvailablePlugins);
+    }
+}

--- a/tests/Vido.Tests/StatePersistenceTests.cs
+++ b/tests/Vido.Tests/StatePersistenceTests.cs
@@ -1,4 +1,6 @@
 using NSubstitute;
+using Vido.Core.Logging;
+using Vido.Core.Plugin;
 using Vido.Core.Settings;
 using Vido.Core.State;
 using Vido.ViewModels;
@@ -206,6 +208,8 @@ public sealed class StatePersistenceTests
         svc.Current.RightPanelWidth = 350;
         svc.Current.StatusBarVisible = false;
         svc.Current.ShowHiddenFiles = true;
+        svc.Current.PluginInstalledSectionExpanded = false;
+        svc.Current.PluginAvailableSectionExpanded = false;
 
         await svc.SaveAsync();
 
@@ -225,10 +229,72 @@ public sealed class StatePersistenceTests
         Assert.Equal(350, svc2.Current.RightPanelWidth);
         Assert.False(svc2.Current.StatusBarVisible);
         Assert.True(svc2.Current.ShowHiddenFiles);
+        Assert.False(svc2.Current.PluginInstalledSectionExpanded);
+        Assert.False(svc2.Current.PluginAvailableSectionExpanded);
         }
         finally
         {
             try { Directory.Delete(tempDir, recursive: true); } catch { }
         }
+    }
+
+    // ── PluginManagerViewModel persists section expanded state ──
+
+    [Fact]
+    public void PluginManagerVM_RestoresSectionState_FromSettings()
+    {
+        var (host, installer, settings, log) = CreatePluginMocks();
+        settings.Current.Returns(new AppSettings
+        {
+            PluginInstalledSectionExpanded = false,
+            PluginAvailableSectionExpanded = false
+        });
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+
+        Assert.False(vm.IsInstalledExpanded);
+        Assert.False(vm.IsAvailableExpanded);
+    }
+
+    [Fact]
+    public void PluginManagerVM_ToggleInstalledExpanded_SavesSettings()
+    {
+        var (host, installer, settings, log) = CreatePluginMocks();
+        var appSettings = new AppSettings();
+        settings.Current.Returns(appSettings);
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        Assert.True(vm.IsInstalledExpanded);
+
+        vm.IsInstalledExpanded = false;
+
+        Assert.False(appSettings.PluginInstalledSectionExpanded);
+        settings.Received().QueueSave();
+    }
+
+    [Fact]
+    public void PluginManagerVM_ToggleAvailableExpanded_SavesSettings()
+    {
+        var (host, installer, settings, log) = CreatePluginMocks();
+        var appSettings = new AppSettings();
+        settings.Current.Returns(appSettings);
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        Assert.True(vm.IsAvailableExpanded);
+
+        vm.IsAvailableExpanded = false;
+
+        Assert.False(appSettings.PluginAvailableSectionExpanded);
+        settings.Received().QueueSave();
+    }
+
+    private static (IPluginHost host, IPluginInstaller installer, ISettingsService settings, ILogService log) CreatePluginMocks()
+    {
+        var host = Substitute.For<IPluginHost>();
+        var installer = Substitute.For<IPluginInstaller>();
+        var settings = Substitute.For<ISettingsService>();
+        var log = Substitute.For<ILogService>();
+        host.Plugins.Returns(Array.Empty<PluginInfo>());
+        return (host, installer, settings, log);
     }
 }


### PR DESCRIPTION
Implement the complete Plugin Manager sidebar panel, detail panel, sample plugin, and end-to-end testing guide — Parts A through G.

Part A — Plugin Manager Sidebar Panel
- PluginManagerViewModel with multi-registry fetch, search/filter by title and tags, registry source dropdown, install/uninstall/enable /disable commands
- PluginManagerPanel.xaml with search bar, registry dropdown, collapsible INSTALLED/AVAILABLE sections with count badges
- Plugin items display icon, title, description, publisher with verified badge for official registry plugins
- Installed plugins show settings cog, enable/disable toggle, status pill, and red uninstall button
- Available plugins show blue install button

Part B — Plugin Detail Panel
- PluginDetailPanel.xaml opens as a tab in the main editor area
- Header with icon, title, publisher, description, and inline Install/Uninstall + Enable/Disable action buttons
- Left content area (75%) with Details, Changelog, and Settings tabs
- Right metadata pane (25%) with version, tags, last updated, license
- Real-time reactivity to sidebar state changes via PropertyChanged

Part C — Interactive Plugin Settings
- SettingDisplayItem ViewModel with type-aware controls: boolean → ComboBox, string → TextBox, number → numeric TextBox, enum → ComboBox
- Settings persist immediately via PluginSettingsStore (no save button)
- Section grouping with headers and dividers when section is specified
- forceOverride support for developer-mandated defaults

Part D — Sample Plugin (vido-sample-plugin)
- Standalone .NET 8 class library at c:\source\vido-sample-plugin\
- Exercises all 9 extension points: sidebar panel, bottom panel tab, right panel tab, status bar item, toolbar button, context menu item, file handler, file icon, keyboard shortcut (Ctrl+Shift+H)
- Declares all 4 setting types (boolean, string, number, enum) across two sections with forceOverride demonstration
- Includes plugin.json manifest, README.md, CHANGELOG.md, registry.json, and package.ps1 build script

Part E — Registry Setup
- Local registry.json with sample plugin entry for development testing

Part F — Testing Guide
- Context/PLUGIN_TESTING_GUIDE.md with step-by-step instructions covering installation, every contributed UI element, settings interaction, enable/disable, uninstall, and troubleshooting

Part G — Unit Tests
- 104 tests covering PluginManagerViewModel, PluginItemViewModel, SettingDisplayItem, PluginInstaller, and sidebar display logic
- Registry fetch, search/filter, multi-registry, install/uninstall state tracking, settings type controls, verified badge, count badges

New files:
- src/Vido.Views/Panels/PluginManagerPanel.xaml(.cs)
- src/Vido.Views/Panels/PluginDetailPanel.xaml(.cs)
- src/Vido.ViewModels/PluginManagerViewModel.cs
- src/Vido.ViewModels/PluginItemViewModel.cs
- src/Vido.ViewModels/SettingDisplayItem.cs
- src/Vido.Core/Plugin/IPluginInstaller.cs
- src/Vido.Core/Plugin/PluginRegistryEntry.cs
- src/Vido.Core/Plugin/PluginPaths.cs
- src/Vido.Services/Plugin/PluginInstaller.cs
- tests/Vido.Tests/PluginManagerTests.cs
- Context/PLUGIN_TESTING_GUIDE.md

Modified files:
- src/Vido.App/App.xaml.cs (DI registration for IPluginInstaller)
- src/Vido.Views/MainWindow.xaml.cs (wiring PluginManagerViewModel, hosting panels in sidebar and main tab area)

731 tests passing, 0 errors.