### PR TITLE
Refactor contribution registry for snapshot caching and improve perfo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,29 @@ All notable changes to the Vido project will be documented in this file.
 - Replaced per-read LINQ filtering/sorting allocations in `GetEntries` with allocation-free snapshot lookup.
 - Added `ContextMenuRegistry` tests for snapshot reference reuse and rebuild-on-mutation behavior.
 
+### vido-122
+- Refactored `ContributionRegistry` to maintain copy-on-write cached snapshots for all `Get*` contribution query methods and file icons.
+- Rebuilt contribution snapshots on registration/unregister mutations, removing per-query `ToList()` and dictionary-copy allocations.
+- Added snapshot-reference tests across sidebar, panel, status bar, toolbar, context menu, file handler, control bar, and file icon queries.
+
+### vido-123
+- Replaced loading spinner `DispatcherTimer` loops with `Storyboard` + `DoubleAnimation` in both `VideoPlayerControl` and `FileExplorerPanel`.
+- Moved spinner rotation animation work to WPF composition pipeline while preserving start/stop behavior and rotation reset semantics.
+
+### vido-124
+- Added cached deterministic shutter WAV payload (`Lazy<byte[]>`) in `MainWindow` and extracted synthesis into `GenerateShutterWav()`.
+- Updated screenshot sound playback to reuse cached bytes instead of regenerating PCM/WAV data on every screenshot.
+
+### vido-125
+- Reworked `PluginSettingsStore` to debounce writes with `System.Threading.Timer`, coalescing rapid `Set`/`Reset`/`ResetAll` updates.
+- Added `Flush()` and `Dispose()` to persist pending changes reliably at shutdown/deactivation boundaries.
+- Updated `PluginHost` deactivation/removal flows to flush/dispose plugin settings stores and added tests for debounce coalescing and flush/dispose persistence.
+
+### vido-126
+- Updated `OutputLogViewModel`, `FileExplorerViewModel`, and `PluginManagerViewModel` to use collection reassignment for batched UI updates.
+- Replaced clear-and-add loops in filter/sort paths with single collection replacement assignments.
+- Added tests verifying collection reference replacement behavior for output log filtering, explorer root sorting, and plugin manager filtering.
+
 ### Process / Agent Governance
 - Added mandatory zero-warning rule for touched repositories (build + test warning-free) to all agent definitions.
 - Added mandatory ticket strike-through updates in solution documents after completion.

--- a/src/Vido.PluginHost/ContributionRegistry.cs
+++ b/src/Vido.PluginHost/ContributionRegistry.cs
@@ -1,4 +1,5 @@
-﻿using Vido.Core.FileSystem;
+﻿using System.Collections.ObjectModel;
+using Vido.Core.FileSystem;
 using Vido.Core.Keyboard;
 using Vido.Core.Layout;
 using Vido.Core.Plugin;
@@ -23,6 +24,17 @@ public sealed class ContributionRegistry : IContributionRegistry
     private readonly List<FileHandlerRegistration> _fileHandlers = [];
     private readonly List<ControlBarRegistration> _controlBarItems = [];
     private readonly Dictionary<string, string> _fileIcons = new(StringComparer.OrdinalIgnoreCase);
+
+    private IReadOnlyList<SidebarRegistration> _sidebarsSnapshot = Array.Empty<SidebarRegistration>();
+    private IReadOnlyList<PanelRegistration> _bottomPanelsSnapshot = Array.Empty<PanelRegistration>();
+    private IReadOnlyList<PanelRegistration> _rightPanelsSnapshot = Array.Empty<PanelRegistration>();
+    private IReadOnlyList<StatusBarRegistration> _statusBarItemsSnapshot = Array.Empty<StatusBarRegistration>();
+    private IReadOnlyList<ToolbarButtonRegistration> _toolbarButtonsSnapshot = Array.Empty<ToolbarButtonRegistration>();
+    private IReadOnlyList<ContextMenuRegistration> _contextMenuItemsSnapshot = Array.Empty<ContextMenuRegistration>();
+    private IReadOnlyList<FileHandlerRegistration> _fileHandlersSnapshot = Array.Empty<FileHandlerRegistration>();
+    private IReadOnlyList<ControlBarRegistration> _controlBarItemsSnapshot = Array.Empty<ControlBarRegistration>();
+    private IReadOnlyDictionary<string, string> _fileIconsSnapshot =
+        new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
 
     // Track which plugin registered which file icon extensions for cleanup
     private readonly Dictionary<string, List<string>> _pluginFileIconKeys = [];
@@ -64,15 +76,60 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// Inserts an item into a sorted list using binary search for O(log n) insertion,
     /// then fires ContributionsChanged.
     /// </summary>
-    private void InsertSorted<T>(List<T> list, T item, Comparison<T> comparison)
+    private void InsertSorted<T>(List<T> list, T item, Comparison<T> comparison, Action rebuildSnapshot)
     {
         lock (_lock)
         {
             var index = list.BinarySearch(item, Comparer<T>.Create(comparison));
             if (index < 0) index = ~index;
             list.Insert(index, item);
+            rebuildSnapshot();
         }
         ContributionsChanged?.Invoke();
+    }
+
+    private void RebuildSidebarSnapshot() =>
+        Volatile.Write(ref _sidebarsSnapshot, _sidebars.ToList().AsReadOnly());
+
+    private void RebuildBottomPanelsSnapshot() =>
+        Volatile.Write(ref _bottomPanelsSnapshot, _bottomPanels.ToList().AsReadOnly());
+
+    private void RebuildRightPanelsSnapshot() =>
+        Volatile.Write(ref _rightPanelsSnapshot, _rightPanels.ToList().AsReadOnly());
+
+    private void RebuildStatusBarItemsSnapshot() =>
+        Volatile.Write(ref _statusBarItemsSnapshot, _statusBarItems.ToList().AsReadOnly());
+
+    private void RebuildToolbarButtonsSnapshot() =>
+        Volatile.Write(ref _toolbarButtonsSnapshot, _toolbarButtons.ToList().AsReadOnly());
+
+    private void RebuildContextMenuItemsSnapshot() =>
+        Volatile.Write(ref _contextMenuItemsSnapshot, _contextMenuItems.ToList().AsReadOnly());
+
+    private void RebuildFileHandlersSnapshot() =>
+        Volatile.Write(ref _fileHandlersSnapshot, _fileHandlers.ToList().AsReadOnly());
+
+    private void RebuildControlBarItemsSnapshot() =>
+        Volatile.Write(ref _controlBarItemsSnapshot, _controlBarItems.ToList().AsReadOnly());
+
+    private void RebuildFileIconsSnapshot()
+    {
+        var snapshot = new ReadOnlyDictionary<string, string>(
+            new Dictionary<string, string>(_fileIcons, StringComparer.OrdinalIgnoreCase));
+        Volatile.Write(ref _fileIconsSnapshot, snapshot);
+    }
+
+    private void RebuildAllSnapshots()
+    {
+        RebuildSidebarSnapshot();
+        RebuildBottomPanelsSnapshot();
+        RebuildRightPanelsSnapshot();
+        RebuildStatusBarItemsSnapshot();
+        RebuildToolbarButtonsSnapshot();
+        RebuildContextMenuItemsSnapshot();
+        RebuildFileHandlersSnapshot();
+        RebuildControlBarItemsSnapshot();
+        RebuildFileIconsSnapshot();
     }
 
     // â”€â”€ Registration â”€â”€
@@ -95,7 +152,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildSidebarSnapshot);
     }
 
     /// <summary>
@@ -115,7 +173,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildBottomPanelsSnapshot);
     }
 
     /// <summary>
@@ -135,7 +194,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildRightPanelsSnapshot);
     }
 
     /// <summary>
@@ -156,7 +216,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildStatusBarItemsSnapshot);
     }
 
     /// <summary>
@@ -177,7 +238,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildToolbarButtonsSnapshot);
     }
 
     /// <summary>
@@ -218,7 +280,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildContextMenuItemsSnapshot);
     }
     
     /// <summary>
@@ -233,6 +296,7 @@ public sealed class ContributionRegistry : IContributionRegistry
         lock (_lock)
         {
             _fileHandlers.Add(new FileHandlerRegistration(pluginId, extensions, handler));
+            RebuildFileHandlersSnapshot();
         }
         ContributionsChanged?.Invoke();
     }
@@ -257,6 +321,8 @@ public sealed class ContributionRegistry : IContributionRegistry
                 _pluginFileIconKeys[pluginId] = keys;
             else
                 existing.AddRange(keys);
+
+            RebuildFileIconsSnapshot();
         }
         ContributionsChanged?.Invoke();
     }
@@ -293,7 +359,8 @@ public sealed class ContributionRegistry : IContributionRegistry
             {
                 var cmp = a.Order.CompareTo(b.Order);
                 return cmp != 0 ? cmp : string.Compare(a.PluginId, b.PluginId, StringComparison.OrdinalIgnoreCase);
-            });
+            },
+            RebuildControlBarItemsSnapshot);
     }
 
     /// <summary>
@@ -378,7 +445,7 @@ public sealed class ContributionRegistry : IContributionRegistry
 
     public IReadOnlyList<SidebarRegistration> GetSidebarPanels()
     {
-        lock (_lock) return _sidebars.ToList();
+        return Volatile.Read(ref _sidebarsSnapshot);
     }
 
     /// <summary>
@@ -386,7 +453,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<PanelRegistration> GetBottomPanels()
     {
-        lock (_lock) return _bottomPanels.ToList();
+        return Volatile.Read(ref _bottomPanelsSnapshot);
     }
 
     /// <summary>
@@ -394,7 +461,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<PanelRegistration> GetRightPanels()
     {
-        lock (_lock) return _rightPanels.ToList();
+        return Volatile.Read(ref _rightPanelsSnapshot);
     }
 
     /// <summary>
@@ -402,7 +469,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<StatusBarRegistration> GetStatusBarItems()
     {
-        lock (_lock) return _statusBarItems.ToList();
+        return Volatile.Read(ref _statusBarItemsSnapshot);
     }
 
     /// <summary>
@@ -410,7 +477,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<ToolbarButtonRegistration> GetToolbarButtons()
     {
-        lock (_lock) return _toolbarButtons.ToList();
+        return Volatile.Read(ref _toolbarButtonsSnapshot);
     }
 
     /// <summary>
@@ -418,7 +485,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<ContextMenuRegistration> GetContextMenuItems()
     {
-        lock (_lock) return _contextMenuItems.ToList();
+        return Volatile.Read(ref _contextMenuItemsSnapshot);
     }
 
     /// <summary>
@@ -426,7 +493,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<FileHandlerRegistration> GetFileHandlers()
     {
-        lock (_lock) return _fileHandlers.ToList();
+        return Volatile.Read(ref _fileHandlersSnapshot);
     }
 
     /// <summary>
@@ -434,7 +501,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyDictionary<string, string> GetFileIcons()
     {
-        lock (_lock) return new Dictionary<string, string>(_fileIcons, StringComparer.OrdinalIgnoreCase);
+        return Volatile.Read(ref _fileIconsSnapshot);
     }
 
     /// <summary>
@@ -442,7 +509,7 @@ public sealed class ContributionRegistry : IContributionRegistry
     /// </summary>
     public IReadOnlyList<ControlBarRegistration> GetControlBarItems()
     {
-        lock (_lock) return _controlBarItems.ToList();
+        return Volatile.Read(ref _controlBarItemsSnapshot);
     }
 
     /// <summary>
@@ -495,6 +562,8 @@ public sealed class ContributionRegistry : IContributionRegistry
                 _playlistProvider = null;
                 _playlistProviderPluginId = null;
             }
+
+            RebuildAllSnapshots();
         }
         ContributionsChanged?.Invoke();
     }

--- a/src/Vido.PluginHost/PluginHost.cs
+++ b/src/Vido.PluginHost/PluginHost.cs
@@ -582,6 +582,11 @@ public sealed class PluginHost : IPluginHost
             _contexts.Remove(info.Manifest.Id);
         }
 
+        if (_settingsStores.TryGetValue(info.Manifest.Id, out var settingsStore))
+        {
+            try { settingsStore.Flush(); } catch (Exception flushEx) { _logService.Debug($"Settings flush during deactivation threw: {flushEx.Message}", "PluginHost"); }
+        }
+
         info.State = PluginState.Deactivated;
         _logService.Info($"Plugin '{info.Manifest.Id}' deactivated", "PluginHost");
     }
@@ -627,7 +632,10 @@ public sealed class PluginHost : IPluginHost
             _contexts.Remove(pluginId);
         }
 
-        _settingsStores.Remove(pluginId);
+        if (_settingsStores.Remove(pluginId, out var settingsStore))
+        {
+            try { settingsStore.Dispose(); } catch (Exception disposeEx) { _logService.Debug($"Settings store dispose during removal threw: {disposeEx.Message}", "PluginHost"); }
+        }
 
         // Remove from disabled list so reinstallation starts fresh
         _settingsService.Current.DisabledPluginIds.RemoveAll(id =>

--- a/src/Vido.PluginHost/PluginSettingsStore.cs
+++ b/src/Vido.PluginHost/PluginSettingsStore.cs
@@ -6,15 +6,23 @@ namespace Vido.PluginHost;
 /// <summary>
 /// Per-plugin settings store backed by a JSON file at
 /// <c>%APPDATA%/Vido/plugins/{pluginId}/settings.json</c>.
-/// Loads lazily on first access; saves on every write.
+/// Loads lazily on first access; writes are debounced to reduce disk I/O.
 /// Thread-safe.
 /// </summary>
-public sealed class PluginSettingsStore : IPluginSettingsStore
+public sealed class PluginSettingsStore : IPluginSettingsStore, IDisposable
 {
+    private const int DefaultDebounceMs = 500;
+
     private readonly string _settingsFilePath;
     private readonly object _lock = new();
+    private readonly int _debounceMs;
+    private readonly Action? _onSave;
+
     private Dictionary<string, JsonElement> _store = [];
     private bool _loaded;
+    private bool _dirty;
+    private bool _disposed;
+    private Timer? _debounceTimer;
 
     private static readonly JsonSerializerOptions s_jsonOptions = new()
     {
@@ -37,6 +45,7 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
         var pluginDir = Path.Combine(appData, "Vido", "plugins", pluginId);
         _settingsFilePath = Path.Combine(pluginDir, "settings.json");
+        _debounceMs = DefaultDebounceMs;
     }
 
     /// <summary>
@@ -47,9 +56,24 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
         return new PluginSettingsStore(settingsFilePath, isExplicitPath: true);
     }
 
-    private PluginSettingsStore(string filePath, bool isExplicitPath)
+    /// <summary>
+    /// Creates a settings store backed by a specific file path (for testing),
+    /// with an optional debounce interval override and save callback.
+    /// </summary>
+    internal static PluginSettingsStore ForTesting(string settingsFilePath, int debounceMs, Action? onSave)
+    {
+        return new PluginSettingsStore(settingsFilePath, isExplicitPath: true, debounceMs, onSave);
+    }
+
+    private PluginSettingsStore(
+        string filePath,
+        bool isExplicitPath,
+        int debounceMs = DefaultDebounceMs,
+        Action? onSave = null)
     {
         _settingsFilePath = filePath;
+        _debounceMs = debounceMs;
+        _onSave = onSave;
     }
 
     /// <summary>
@@ -81,7 +105,7 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
 
     /// <summary>
     /// Stores a setting value under the given key, serializing it to JSON.
-    /// Persists the change to disk immediately and raises <see cref="SettingChanged"/>.
+    /// Schedules persistence and raises <see cref="SettingChanged"/>.
     /// </summary>
     /// <param name="key">The setting key to write.</param>
     /// <param name="value">The value to serialize and store.</param>
@@ -93,7 +117,8 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
 
             var json = JsonSerializer.SerializeToElement(value, s_jsonOptions);
             _store[key] = json;
-            Save();
+            _dirty = true;
+            QueueSave();
         }
 
         SettingChanged?.Invoke(key);
@@ -112,7 +137,10 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
             EnsureLoaded();
             removed = _store.Remove(key);
             if (removed)
-                Save();
+            {
+                _dirty = true;
+                QueueSave();
+            }
         }
 
         if (removed)
@@ -133,7 +161,8 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
             EnsureLoaded();
             keys = [.. _store.Keys];
             _store.Clear();
-            Save();
+            _dirty = true;
+            QueueSave();
         }
 
         foreach (var key in keys)
@@ -162,8 +191,61 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
         }
     }
 
-    private void Save()
+    /// <summary>
+    /// Schedules persistence after a short delay to coalesce rapid writes.
+    /// Must be called while holding <see cref="_lock"/>.
+    /// </summary>
+    private void QueueSave()
     {
+        if (_disposed) return;
+
+        if (_debounceTimer is null)
+        {
+            _debounceTimer = new Timer(_ =>
+            {
+                lock (_lock)
+                    SaveIfDirty();
+            }, null, _debounceMs, Timeout.Infinite);
+            return;
+        }
+
+        _debounceTimer.Change(_debounceMs, Timeout.Infinite);
+    }
+
+    /// <summary>
+    /// Immediately persists pending changes, if any.
+    /// </summary>
+    public void Flush()
+    {
+        lock (_lock)
+        {
+            _debounceTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            SaveIfDirty();
+        }
+    }
+
+    /// <summary>
+    /// Flushes pending changes and disposes timer resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Timer? timer;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            timer = _debounceTimer;
+            _debounceTimer = null;
+            SaveIfDirty();
+        }
+
+        timer?.Dispose();
+    }
+
+    private void SaveIfDirty()
+    {
+        if (!_dirty) return;
+
         try
         {
             var dir = Path.GetDirectoryName(_settingsFilePath);
@@ -172,6 +254,8 @@ public sealed class PluginSettingsStore : IPluginSettingsStore
 
             var json = JsonSerializer.Serialize(_store, s_jsonOptions);
             File.WriteAllText(_settingsFilePath, json);
+            _dirty = false;
+            _onSave?.Invoke();
         }
         catch
         {

--- a/src/Vido.ViewModels/FileExplorerViewModel.cs
+++ b/src/Vido.ViewModels/FileExplorerViewModel.cs
@@ -472,13 +472,9 @@ public partial class FileExplorerViewModel : ObservableObject
     /// </summary>
     private void SortRootNodes()
     {
-        var sorted = RootNodes
+        RootNodes = new ObservableCollection<FileNode>(RootNodes
             .OrderByDescending(n => n.IsDirectory)
             .ThenBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
-            .ToList();
-
-        RootNodes.Clear();
-        foreach (var node in sorted)
-            RootNodes.Add(node);
+            .ToList());
     }
 }

--- a/src/Vido.ViewModels/OutputLogViewModel.cs
+++ b/src/Vido.ViewModels/OutputLogViewModel.cs
@@ -19,7 +19,8 @@ public partial class OutputLogViewModel : ObservableObject, IDisposable
     /// <summary>
     /// Filtered log entries currently displayed in the panel.
     /// </summary>
-    public ObservableCollection<LogEntryViewModel> Entries { get; } = [];
+    [ObservableProperty]
+    private ObservableCollection<LogEntryViewModel> _entries = [];
 
     /// <summary>
     /// Whether auto-scroll to the latest entry is enabled.
@@ -89,7 +90,7 @@ public partial class OutputLogViewModel : ObservableObject, IDisposable
     public void ClearLog()
     {
         _logService.Clear();
-        Entries.Clear();
+        Entries = [];
         HasEntries = false;
     }
 
@@ -141,13 +142,10 @@ public partial class OutputLogViewModel : ObservableObject, IDisposable
 
     private void RebuildFilteredEntries()
     {
-        Entries.Clear();
-        foreach (var entry in _logService.Entries)
-        {
-            if (entry.Level >= _minimumLevel)
-                Entries.Add(new LogEntryViewModel(entry));
-        }
-
+        Entries = new ObservableCollection<LogEntryViewModel>(
+            _logService.Entries
+                .Where(entry => entry.Level >= _minimumLevel)
+                .Select(entry => new LogEntryViewModel(entry)));
         HasEntries = Entries.Count > 0;
     }
 

--- a/src/Vido.ViewModels/PluginManagerViewModel.cs
+++ b/src/Vido.ViewModels/PluginManagerViewModel.cs
@@ -31,12 +31,14 @@ public partial class PluginManagerViewModel : ObservableObject
     /// <summary>
     /// Installed plugins filtered by search and registry.
     /// </summary>
-    public ObservableCollection<PluginItemViewModel> InstalledPlugins { get; } = [];
+    [ObservableProperty]
+    private ObservableCollection<PluginItemViewModel> _installedPlugins = [];
 
     /// <summary>
     /// Available plugins filtered by search and registry.
     /// </summary>
-    public ObservableCollection<PluginItemViewModel> AvailablePlugins { get; } = [];
+    [ObservableProperty]
+    private ObservableCollection<PluginItemViewModel> _availablePlugins = [];
 
     /// <summary>
     /// Registry source options for the dropdown.
@@ -738,8 +740,8 @@ public partial class PluginManagerViewModel : ObservableObject
     /// </summary>
     private void ApplyFilter()
     {
-        InstalledPlugins.Clear();
-        AvailablePlugins.Clear();
+        var installed = new List<PluginItemViewModel>();
+        var available = new List<PluginItemViewModel>();
 
         foreach (var item in _allPlugins)
         {
@@ -759,10 +761,13 @@ public partial class PluginManagerViewModel : ObservableObject
             }
 
             if (item.IsInstalled)
-                InstalledPlugins.Add(item);
+                installed.Add(item);
             else
-                AvailablePlugins.Add(item);
+                available.Add(item);
         }
+
+        InstalledPlugins = new ObservableCollection<PluginItemViewModel>(installed);
+        AvailablePlugins = new ObservableCollection<PluginItemViewModel>(available);
 
         InstalledCount = InstalledPlugins.Count;
         AvailableCount = AvailablePlugins.Count;

--- a/src/Vido.Views/Controls/VideoPlayerControl.xaml.cs
+++ b/src/Vido.Views/Controls/VideoPlayerControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using Vido.Core.Playback;
@@ -19,7 +20,7 @@ public partial class VideoPlayerControl : UserControl
 {
     private WriteableBitmap? _bitmap;
     private VideoPlayerViewModel? _viewModel;
-    private DispatcherTimer? _loadingSpinnerTimer;
+    private Storyboard? _loadingSpinnerStoryboard;
     private FrameData? _pendingFrame;
     private int _renderQueued;
 
@@ -166,23 +167,28 @@ public partial class VideoPlayerControl : UserControl
 
     private void StartLoadingSpinner()
     {
-        if (_loadingSpinnerTimer is not null) return;
+        if (_loadingSpinnerStoryboard is not null) return;
 
-        _loadingSpinnerTimer = new DispatcherTimer(DispatcherPriority.Render)
+        var animation = new DoubleAnimation
         {
-            Interval = TimeSpan.FromMilliseconds(16)
+            From = 0,
+            To = 360,
+            Duration = TimeSpan.FromSeconds(1),
+            RepeatBehavior = RepeatBehavior.Forever
         };
-        _loadingSpinnerTimer.Tick += (_, _) =>
-        {
-            LoadingSpinnerRotation.Angle = (LoadingSpinnerRotation.Angle + 6) % 360;
-        };
-        _loadingSpinnerTimer.Start();
+
+        Storyboard.SetTarget(animation, LoadingSpinnerRotation);
+        Storyboard.SetTargetProperty(animation, new PropertyPath(RotateTransform.AngleProperty));
+
+        _loadingSpinnerStoryboard = new Storyboard();
+        _loadingSpinnerStoryboard.Children.Add(animation);
+        _loadingSpinnerStoryboard.Begin();
     }
 
     private void StopLoadingSpinner()
     {
-        _loadingSpinnerTimer?.Stop();
-        _loadingSpinnerTimer = null;
+        _loadingSpinnerStoryboard?.Stop();
+        _loadingSpinnerStoryboard = null;
         LoadingSpinnerRotation.Angle = 0;
     }
 

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -95,6 +95,12 @@ public partial class MainWindow : Window
     private bool _controlsVisible = true;
     private const int FullscreenHideDelayMs = 3000;
     private const int ControlsFadeDurationMs = 200;
+
+    /// <summary>
+    /// Lazily generated WAV data for the screenshot shutter sound.
+    /// Deterministic synthesis means this can be generated once and reused.
+    /// </summary>
+    private static readonly Lazy<byte[]> s_shutterWav = new(GenerateShutterWav);
     
     /// <summary>
     /// Creates the main application window, wiring up all services, view models, and UI subsystems
@@ -2834,87 +2840,7 @@ public partial class MainWindow : Window
     {
         try
         {
-            const int sampleRate = 22050;
-            const int channels = 1;
-            const int bitsPerSample = 16;
-            const double totalSeconds = 0.12;
-            int totalSamples = (int)(sampleRate * totalSeconds);
-            int byteRate = sampleRate * channels * bitsPerSample / 8;
-            int blockAlign = channels * bitsPerSample / 8;
-            int dataSize = totalSamples * blockAlign;
-
-            using var ms = new MemoryStream();
-            using var bw = new BinaryWriter(ms);
-
-            // WAV header
-            bw.Write("RIFF"u8);
-            bw.Write(36 + dataSize);
-            bw.Write("WAVE"u8);
-            bw.Write("fmt "u8);
-            bw.Write(16);            // chunk size
-            bw.Write((short)1);      // PCM
-            bw.Write((short)channels);
-            bw.Write(sampleRate);
-            bw.Write(byteRate);
-            bw.Write((short)blockAlign);
-            bw.Write((short)bitsPerSample);
-            bw.Write("data"u8);
-            bw.Write(dataSize);
-
-            // Synthesize a mechanical shutter click:
-            // Phase 1 (0-40ms): sharp attack noise burst (mirror slap)
-            // Phase 2 (40-60ms): quiet gap
-            // Phase 3 (60-90ms): softer click (shutter curtain)
-            // Phase 4 (90-120ms): rapid decay
-            var rng = new Random(42); // deterministic seed for consistent sound
-            for (int i = 0; i < totalSamples; i++)
-            {
-                double t = (double)i / sampleRate;
-                double amplitude;
-
-                if (t < 0.005)
-                {
-                    // Sharp attack ramp
-                    amplitude = t / 0.005 * 0.9;
-                }
-                else if (t < 0.040)
-                {
-                    // First click body — exponential decay
-                    amplitude = 0.9 * Math.Exp(-(t - 0.005) * 60);
-                }
-                else if (t < 0.060)
-                {
-                    // Quiet gap between clicks
-                    amplitude = 0.02;
-                }
-                else if (t < 0.065)
-                {
-                    // Second click attack
-                    amplitude = (t - 0.060) / 0.005 * 0.5;
-                }
-                else if (t < 0.090)
-                {
-                    // Second click body
-                    amplitude = 0.5 * Math.Exp(-(t - 0.065) * 80);
-                }
-                else
-                {
-                    // Tail decay
-                    amplitude = 0.1 * Math.Exp(-(t - 0.090) * 100);
-                }
-
-                // Filtered noise: mix of broadband noise and a low thunk tone
-                double noise = (rng.NextDouble() * 2 - 1);
-                double thunk = Math.Sin(2 * Math.PI * 180 * t) * 0.4;
-                double sample = (noise * 0.6 + thunk) * amplitude;
-
-                // Clamp and write 16-bit PCM
-                short pcm = (short)Math.Clamp(sample * 16000, short.MinValue, short.MaxValue);
-                bw.Write(pcm);
-            }
-
-            bw.Flush();
-            ms.Position = 0;
+            using var ms = new MemoryStream(s_shutterWav.Value, writable: false);
             var player = new System.Media.SoundPlayer(ms);
             player.Play();
         }
@@ -2922,6 +2848,81 @@ public partial class MainWindow : Window
         {
             // Sound is non-critical — swallow any errors
         }
+    }
+
+    /// <summary>
+    /// Generates deterministic WAV data for the screenshot shutter sound.
+    /// Called once via <see cref="s_shutterWav"/>.
+    /// </summary>
+    private static byte[] GenerateShutterWav()
+    {
+        const int sampleRate = 22050;
+        const int channels = 1;
+        const int bitsPerSample = 16;
+        const double totalSeconds = 0.12;
+        int totalSamples = (int)(sampleRate * totalSeconds);
+        int byteRate = sampleRate * channels * bitsPerSample / 8;
+        int blockAlign = channels * bitsPerSample / 8;
+        int dataSize = totalSamples * blockAlign;
+
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms);
+
+        bw.Write("RIFF"u8);
+        bw.Write(36 + dataSize);
+        bw.Write("WAVE"u8);
+        bw.Write("fmt "u8);
+        bw.Write(16);
+        bw.Write((short)1);
+        bw.Write((short)channels);
+        bw.Write(sampleRate);
+        bw.Write(byteRate);
+        bw.Write((short)blockAlign);
+        bw.Write((short)bitsPerSample);
+        bw.Write("data"u8);
+        bw.Write(dataSize);
+
+        var rng = new Random(42);
+        for (int i = 0; i < totalSamples; i++)
+        {
+            double t = (double)i / sampleRate;
+            double amplitude;
+
+            if (t < 0.005)
+            {
+                amplitude = t / 0.005 * 0.9;
+            }
+            else if (t < 0.040)
+            {
+                amplitude = 0.9 * Math.Exp(-(t - 0.005) * 60);
+            }
+            else if (t < 0.060)
+            {
+                amplitude = 0.02;
+            }
+            else if (t < 0.065)
+            {
+                amplitude = (t - 0.060) / 0.005 * 0.5;
+            }
+            else if (t < 0.090)
+            {
+                amplitude = 0.5 * Math.Exp(-(t - 0.065) * 80);
+            }
+            else
+            {
+                amplitude = 0.1 * Math.Exp(-(t - 0.090) * 100);
+            }
+
+            double noise = (rng.NextDouble() * 2 - 1);
+            double thunk = Math.Sin(2 * Math.PI * 180 * t) * 0.4;
+            double sample = (noise * 0.6 + thunk) * amplitude;
+
+            short pcm = (short)Math.Clamp(sample * 16000, short.MinValue, short.MaxValue);
+            bw.Write(pcm);
+        }
+
+        bw.Flush();
+        return ms.ToArray();
     }
 
     private void ShowAboutDialog()

--- a/src/Vido.Views/Panels/FileExplorerPanel.xaml.cs
+++ b/src/Vido.Views/Panels/FileExplorerPanel.xaml.cs
@@ -3,8 +3,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
-using System.Windows.Threading;
 using Vido.Core.FileSystem;
 using Vido.Core.Menus;
 using Vido.Core.Plugin;
@@ -98,7 +98,7 @@ public partial class FileExplorerPanel : UserControl
         }
     }
 
-    private DispatcherTimer? _spinnerTimer;
+    private Storyboard? _spinnerStoryboard;
 
     private void UpdateVisualState(bool hasFolderOpen, bool isLoading)
     {
@@ -114,23 +114,28 @@ public partial class FileExplorerPanel : UserControl
 
     private void StartSpinner()
     {
-        if (_spinnerTimer is not null) return;
+        if (_spinnerStoryboard is not null) return;
 
-        _spinnerTimer = new DispatcherTimer(DispatcherPriority.Render)
+        var animation = new DoubleAnimation
         {
-            Interval = TimeSpan.FromMilliseconds(16)
+            From = 0,
+            To = 360,
+            Duration = TimeSpan.FromSeconds(1),
+            RepeatBehavior = RepeatBehavior.Forever
         };
-        _spinnerTimer.Tick += (_, _) =>
-        {
-            SpinnerRotation.Angle = (SpinnerRotation.Angle + 6) % 360;
-        };
-        _spinnerTimer.Start();
+
+        Storyboard.SetTarget(animation, SpinnerRotation);
+        Storyboard.SetTargetProperty(animation, new PropertyPath(RotateTransform.AngleProperty));
+
+        _spinnerStoryboard = new Storyboard();
+        _spinnerStoryboard.Children.Add(animation);
+        _spinnerStoryboard.Begin();
     }
 
     private void StopSpinner()
     {
-        _spinnerTimer?.Stop();
-        _spinnerTimer = null;
+        _spinnerStoryboard?.Stop();
+        _spinnerStoryboard = null;
         SpinnerRotation.Angle = 0;
     }
 

--- a/tests/Vido.Tests/ContributionRegistryTests.cs
+++ b/tests/Vido.Tests/ContributionRegistryTests.cs
@@ -554,6 +554,105 @@ public class ContributionRegistryTests
         Assert.Equal(2, second.Count);
     }
 
+    [Fact]
+    public void GetSidebarPanels_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterSidebarPanel("p1", "s1", "S", null, 10, () => "v");
+
+        var first = _registry.GetSidebarPanels();
+        var second = _registry.GetSidebarPanels();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetBottomPanels_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterBottomPanel("p1", "b1", "B", 10, () => "v");
+
+        var first = _registry.GetBottomPanels();
+        var second = _registry.GetBottomPanels();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetRightPanels_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterRightPanel("p1", "r1", "R", 10, () => "v");
+
+        var first = _registry.GetRightPanels();
+        var second = _registry.GetRightPanels();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetStatusBarItems_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterStatusBarItem("p1", "sb1", "Status", "left", 10, () => "v");
+
+        var first = _registry.GetStatusBarItems();
+        var second = _registry.GetStatusBarItems();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetToolbarButtons_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterToolbarButton("p1", "tb1", "Tip", null, 10, () => { });
+
+        var first = _registry.GetToolbarButtons();
+        var second = _registry.GetToolbarButtons();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetContextMenuItems_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterContextMenuHandler("p1", "ctx1", "Action", [".mp4"], 10, _ => { });
+
+        var first = _registry.GetContextMenuItems();
+        var second = _registry.GetContextMenuItems();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetFileHandlers_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterFileHandler("p1", [".txt"], _ => { });
+
+        var first = _registry.GetFileHandlers();
+        var second = _registry.GetFileHandlers();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetControlBarItems_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterControlBarItem("p1", "cb1", "Control", 10, () => "v", null);
+
+        var first = _registry.GetControlBarItems();
+        var second = _registry.GetControlBarItems();
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetFileIcons_RepeatedCalls_ReturnSameSnapshotReference()
+    {
+        _registry.RegisterFileIcons("p1", new Dictionary<string, string> { [".abc"] = "icon.png" });
+
+        var first = _registry.GetFileIcons();
+        var second = _registry.GetFileIcons();
+
+        Assert.Same(first, second);
+    }
+
     // ╔══════════════════════════════════════════════════════════════════╗
     // ║ vb-017 — Overlay toggle before materialization                 ║
     // ╚══════════════════════════════════════════════════════════════════╝

--- a/tests/Vido.Tests/FileExplorerViewModelTests.cs
+++ b/tests/Vido.Tests/FileExplorerViewModelTests.cs
@@ -164,6 +164,24 @@ public sealed class FileExplorerViewModelTests
     }
 
     /// <summary>
+    /// Verifies that Add Items triggers root node sort via collection reassignment.
+    /// </summary>
+    [Fact]
+    public void AddItems_AssignsNewRootNodesCollection()
+    {
+        var dir = CreateTempDir();
+        var filePath = Path.Combine(dir, "clip.mp4");
+        File.WriteAllText(filePath, "x");
+
+        var before = _sut.RootNodes;
+
+        _sut.AddItems([filePath]);
+
+        Assert.NotSame(before, _sut.RootNodes);
+        CleanupDir(dir);
+    }
+
+    /// <summary>
     /// Verifies that Expand Node delegates to file system service.
     /// </summary>
     [Fact]

--- a/tests/Vido.Tests/OutputLogViewModelTests.cs
+++ b/tests/Vido.Tests/OutputLogViewModelTests.cs
@@ -265,6 +265,19 @@ public sealed class OutputLogViewModelTests
         Assert.Equal("All", _sut.FilterText);
     }
 
+    /// <summary>
+    /// Verifies that Set Filter rebuild assigns a new entries collection instance.
+    /// </summary>
+    [Fact]
+    public void SetFilter_Rebuild_AssignsNewEntriesCollection()
+    {
+        var before = _sut.Entries;
+
+        _sut.SetFilter(LogLevel.Warning);
+
+        Assert.NotSame(before, _sut.Entries);
+    }
+
     // ── LogEntryViewModel formatting ──
 
     /// <summary>

--- a/tests/Vido.Tests/PluginManagerTests.cs
+++ b/tests/Vido.Tests/PluginManagerTests.cs
@@ -354,6 +354,36 @@ public sealed class PluginManagerTests
     }
 
     /// <summary>
+    /// Verifies that Applying filter assigns new collection instances.
+    /// </summary>
+    [Fact]
+    public async Task ApplyFilter_AssignsNewCollections()
+    {
+        var (host, installer, settings, log) = CreateMocks();
+        var registry = new PluginRegistry
+        {
+            Name = "My Registry",
+            Plugins = [
+                MakeEntry(id: "com.test.alpha", displayName: "Alpha"),
+                MakeEntry(id: "com.test.beta", displayName: "Beta")
+            ]
+        };
+
+        installer.FetchRegistryAsync(Arg.Any<string>()).Returns(Task.FromResult<PluginRegistry?>(registry));
+
+        var vm = new PluginManagerViewModel(host, installer, settings, log);
+        await vm.LoadAsync();
+
+        var availableBefore = vm.AvailablePlugins;
+        var installedBefore = vm.InstalledPlugins;
+
+        vm.SearchQuery = "alpha";
+
+        Assert.NotSame(availableBefore, vm.AvailablePlugins);
+        Assert.NotSame(installedBefore, vm.InstalledPlugins);
+    }
+
+    /// <summary>
     /// Verifies that Load Async merges installed with registry.
     /// </summary>
     [Fact]

--- a/tests/Vido.Tests/PluginSettingsStoreTests.cs
+++ b/tests/Vido.Tests/PluginSettingsStoreTests.cs
@@ -84,6 +84,7 @@ public class PluginSettingsStoreTests : IDisposable
     {
         var store = CreateStore();
         store.Set("persistent", "value");
+        store.Flush();
 
         // Create a fresh store instance pointing to the same file
         var store2 = PluginSettingsStore.ForTesting(_settingsFile);
@@ -161,6 +162,7 @@ public class PluginSettingsStoreTests : IDisposable
         var store = PluginSettingsStore.ForTesting(nestedPath);
 
         store.Set("key", "value");
+        store.Flush();
 
         Assert.True(File.Exists(nestedPath));
     }
@@ -188,6 +190,7 @@ public class PluginSettingsStoreTests : IDisposable
         store.Set("a", 1);
         store.Set("b", "two");
         store.Set("c", 3.14);
+        store.Flush();
 
         var store2 = PluginSettingsStore.ForTesting(_settingsFile);
 
@@ -264,6 +267,7 @@ public class PluginSettingsStoreTests : IDisposable
         var store = CreateStore();
         store.Set("key", "value");
         store.Reset("key");
+        store.Flush();
 
         var store2 = PluginSettingsStore.ForTesting(_settingsFile);
         Assert.Equal("default", store2.Get("key", "default"));
@@ -315,8 +319,56 @@ public class PluginSettingsStoreTests : IDisposable
         var store = CreateStore();
         store.Set("key", "val");
         store.ResetAll();
+        store.Flush();
 
         var store2 = PluginSettingsStore.ForTesting(_settingsFile);
         Assert.Equal("default", store2.Get("key", "default"));
+    }
+
+    /// <summary>
+    /// Verifies that Multiple Set calls are coalesced into one debounced save.
+    /// </summary>
+    [Fact]
+    public async Task Set_MultipleTimes_CoalescesToSingleDebouncedSave()
+    {
+        var saveCount = 0;
+        var store = PluginSettingsStore.ForTesting(_settingsFile, debounceMs: 50, onSave: () => saveCount++);
+
+        for (int i = 0; i < 10; i++)
+            store.Set("key", i);
+
+        await Task.Delay(200);
+
+        Assert.Equal(1, saveCount);
+    }
+
+    /// <summary>
+    /// Verifies that Flush writes pending values immediately.
+    /// </summary>
+    [Fact]
+    public void Flush_WritesPendingValuesImmediately()
+    {
+        var store = CreateStore();
+        store.Set("flush-key", "flush-value");
+
+        store.Flush();
+
+        var store2 = PluginSettingsStore.ForTesting(_settingsFile);
+        Assert.Equal("flush-value", store2.Get("flush-key", string.Empty));
+    }
+
+    /// <summary>
+    /// Verifies that Dispose flushes pending changes.
+    /// </summary>
+    [Fact]
+    public void Dispose_FlushesPendingValues()
+    {
+        var store = CreateStore();
+        store.Set("dispose-key", "dispose-value");
+
+        store.Dispose();
+
+        var store2 = PluginSettingsStore.ForTesting(_settingsFile);
+        Assert.Equal("dispose-value", store2.Get("dispose-key", string.Empty));
     }
 }


### PR DESCRIPTION
…rmance

- Refactored `ContributionRegistry` to maintain copy-on-write cached snapshots for all `Get*` contribution query methods and file icons.
- Rebuilt contribution snapshots on registration/unregister mutations, removing per-query allocations.
- Updated `PluginSettingsStore` to debounce writes and added `Flush()` and `Dispose()` methods for reliable persistence.
- Replaced loading spinner `DispatcherTimer` loops with `Storyboard` + `DoubleAnimation` in `VideoPlayerControl` and `FileExplorerPanel`.
- Enhanced UI update performance in `OutputLogViewModel`, `FileExplorerViewModel`, and `PluginManagerViewModel` using collection reassignment.
- Added tests for snapshot reference reuse and debounce behavior across various components.