### PR TITLE
Fix critical application freeze in Serial transport and improve threa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Vido project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **VI-0009**: Fixed critical application freeze when using Serial transport with Pulse (no funscript). Root cause was a race condition between `SerialPort.Close()` on the UI thread and `BaseStream.Write()` on the TCode output thread. `Disconnect()` now closes the port asynchronously on a ThreadPool thread. Added `_sendLock` to serialize concurrent serial writes. `HomeAxes()`, `SendMidpoint()`, and `SendPositionWithOffset()` now enqueue commands via the output thread instead of calling `_transport.Send()` directly from the UI thread. `StopTimer()` join timeout increased from 500ms to 1500ms with a non-blocking fallback.
+
 ## [0.14.0] - 2026-03-03
 
 ### Changed

--- a/src/Vido.Services/Osr2Plus/SerialTransportService.cs
+++ b/src/Vido.Services/Osr2Plus/SerialTransportService.cs
@@ -10,6 +10,7 @@ namespace Vido.Services.Osr2Plus;
 public class SerialTransportService : ITransportService
 {
     private readonly object _lock = new();
+    private readonly object _sendLock = new();
     private SerialPort? _port;
 
     /// <inheritdoc/>
@@ -86,21 +87,19 @@ public class SerialTransportService : ITransportService
     public void Send(ReadOnlySpan<byte> data)
     {
         SerialPort? port;
+        lock (_lock) { port = _port; }
+        if (port?.IsOpen != true) return;
 
-        lock (_lock)
-        {
-            port = _port;
-        }
-
-        if (port?.IsOpen == true)
+        lock (_sendLock)
         {
             try
             {
-                port.BaseStream.Write(data);
+                if (port.IsOpen)
+                    port.BaseStream.Write(data);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is IOException or TimeoutException or InvalidOperationException or UnauthorizedAccessException)
             {
-                ErrorOccurred?.Invoke($"Serial send failed: {ex.Message}");
+                ErrorOccurred?.Invoke($"Serial send error: {ex.Message}");
             }
         }
     }
@@ -108,30 +107,40 @@ public class SerialTransportService : ITransportService
     /// <inheritdoc/>
     public void Disconnect()
     {
-        bool wasConnected;
-
+        SerialPort? portToClose;
         lock (_lock)
         {
-            wasConnected = _port != null;
+            portToClose = _port;
+            _port = null;               // Remove reference immediately so Send() sees null
+        }
 
-            if (_port != null)
+        if (portToClose is null) return;
+
+        var wasConnected = false;
+        try
+        {
+            wasConnected = portToClose.IsOpen;
+            // Close on ThreadPool to avoid blocking UI if a Write is in progress
+            ThreadPool.QueueUserWorkItem(_ =>
             {
                 try
                 {
-                    if (_port.IsOpen)
-                        _port.Close();
+                    portToClose.Close();
+                    portToClose.Dispose();
                 }
-                catch { /* Ignore close errors */ }
-
-                _port.Dispose();
-                _port = null;
-            }
+                catch (Exception)
+                {
+                    // Port may already be dead — best-effort cleanup
+                }
+            });
+        }
+        catch (Exception)
+        {
+            // Ignore — port is being abandoned
         }
 
         if (wasConnected)
-        {
             ConnectionChanged?.Invoke(false);
-        }
     }
 
     /// <summary>

--- a/src/Vido.Services/Osr2Plus/TCodeService.cs
+++ b/src/Vido.Services/Osr2Plus/TCodeService.cs
@@ -20,6 +20,10 @@ public class TCodeService : IDisposable
     private Thread? _outputThread;
     private volatile bool _threadRunning;
 
+    // Pending direct command: written by UI thread (HomeAxes, SendMidpoint, SendPositionWithOffset),
+    // consumed by the output thread to avoid cross-thread serial writes.
+    private string? _pendingDirectCommand;
+
     // Playback state (written by UI thread, read by output thread)
     private volatile bool _isPlaying;
     private volatile float _playbackSpeed = 1.0f;
@@ -341,12 +345,21 @@ public class TCodeService : IDisposable
 
     /// <summary>
     /// Stops the TCode output thread and clears all state.
+    /// Uses a 1500ms join timeout to avoid blocking the UI thread indefinitely
+    /// if the background thread is stuck in a serial write.
     /// </summary>
     public void StopTimer()
     {
         _threadRunning = false;
-        _outputThread?.Join(500);
-        _outputThread = null;
+        if (_outputThread is not null)
+        {
+            if (!_outputThread.Join(1500))
+            {
+                // Thread is stuck in a serial write — it will exit when the write completes
+                // or when the process exits. Do not block the UI.
+            }
+            _outputThread = null;
+        }
         _lastSentValues.Clear();
         lock (_testLock) _testingAxes.Clear();
     }
@@ -498,6 +511,11 @@ public class TCodeService : IDisposable
 
             try
             {
+                // Drain any pending direct command (HomeAxes, SendMidpoint, etc.)
+                var pending = Interlocked.Exchange(ref _pendingDirectCommand, null);
+                if (pending is not null)
+                    _transport?.Send(pending);
+
                 if (_transport?.IsConnected == true)
                 {
                     bool hasTestAxes;
@@ -1040,14 +1058,16 @@ public class TCodeService : IDisposable
     }
 
     /// <summary>
-    /// Sends a midpoint command (500) for the given axis to the transport.
+    /// Enqueues a midpoint command (500) for the given axis.
+    /// The command is sent by the output thread to avoid cross-thread serial writes.
     /// </summary>
     private void SendMidpoint(string axisId)
     {
         var config = FindAxisConfig(axisId);
         if (config == null || _transport?.IsConnected != true) return;
-        _transport.Send(FormatTCodeCommand(config, 500, 500) + "\n");
+        var command = FormatTCodeCommand(config, 500, 500) + "\n";
         _lastSentValues.Remove(axisId);
+        Volatile.Write(ref _pendingDirectCommand, command);
     }
 
     /// <summary>
@@ -1065,8 +1085,9 @@ public class TCodeService : IDisposable
         var baseTcode = PositionToTCode(config, 50.0);
         var offsetTcode = ApplyPositionOffset(config, baseTcode);
 
-        _transport.Send(FormatTCodeCommand(config, offsetTcode, 200) + "\n");
+        var command = FormatTCodeCommand(config, offsetTcode, 200) + "\n";
         _lastSentValues[axisId] = offsetTcode;
+        Volatile.Write(ref _pendingDirectCommand, command);
     }
 
     /// <summary>
@@ -1095,6 +1116,6 @@ public class TCodeService : IDisposable
             _lastSentValues[config.Id] = homeTcode;
         }
 
-        _transport.Send(string.Join(" ", parts) + "\n");
+        Volatile.Write(ref _pendingDirectCommand, string.Join(" ", parts) + "\n");
     }
 }

--- a/tests/Vido.Tests/TCodeEngineTests.cs
+++ b/tests/Vido.Tests/TCodeEngineTests.cs
@@ -927,7 +927,11 @@ public class TCodeEngineTests : IDisposable
             MakeR0()
         });
 
+        // Start output thread so the pending command gets dispatched
+        _service.Start();
         _service.HomeAxes();
+        Thread.Sleep(50);
+        _service.StopTimer();
 
         Assert.True(transport.SentMessages.Count > 0);
         var msg = transport.SentMessages[0];
@@ -961,7 +965,11 @@ public class TCodeEngineTests : IDisposable
         _service.Transport = transport;
         _service.SetAxisConfigs(new List<AxisConfig> { MakeL0(positionOffset: 10) });
 
+        // Start output thread so the pending command gets dispatched
+        _service.Start();
         _service.SendPositionWithOffset("L0");
+        Thread.Sleep(50);
+        _service.StopTimer();
 
         Assert.True(transport.SentMessages.Count > 0);
         var msg = transport.SentMessages[0];

--- a/tests/Vido.Tests/TransportServiceTests.cs
+++ b/tests/Vido.Tests/TransportServiceTests.cs
@@ -353,4 +353,103 @@ public class TransportServiceTests
         // Reconnect should fire: false (disconnect old), true (connect new)
         Assert.Equal([false, true], states);
     }
+
+    // ──────────────────────────────────────────────
+    //  SerialTransportService — Thread Safety (VI-0009)
+    // ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that concurrent <see cref="SerialTransportService.Send(string)"/> calls
+    /// on a disconnected transport do not throw exceptions.
+    /// </summary>
+    [Fact]
+    public void SerialTransport_ConcurrentSend_DoesNotThrow()
+    {
+        using var transport = new SerialTransportService();
+        var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+        var threads = new Thread[4];
+        for (int i = 0; i < threads.Length; i++)
+        {
+            threads[i] = new Thread(() =>
+            {
+                try
+                {
+                    for (int j = 0; j < 100; j++)
+                        transport.Send("L0500I1000\n");
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            });
+        }
+
+        foreach (var t in threads) t.Start();
+        foreach (var t in threads) t.Join(2000);
+
+        Assert.Empty(exceptions);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SerialTransportService.Disconnect"/> returns immediately
+    /// (does not hang waiting for pending writes) even when the transport was never connected.
+    /// </summary>
+    [Fact]
+    public void SerialTransport_DisconnectWhileSending_DoesNotHang()
+    {
+        using var transport = new SerialTransportService();
+        // Start sends on background threads (will no-op since disconnected)
+        var sendThread = new Thread(() =>
+        {
+            for (int i = 0; i < 1000; i++)
+                transport.Send("L0500I1000\n");
+        });
+        sendThread.Start();
+
+        // Disconnect concurrently — must return quickly
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        transport.Disconnect();
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds < 100,
+            $"Disconnect took {sw.ElapsedMilliseconds}ms, expected < 100ms");
+
+        sendThread.Join(2000);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SerialTransportService.IsConnected"/> is false
+    /// immediately after <see cref="SerialTransportService.Disconnect"/> returns
+    /// (even though port close is asynchronous).
+    /// </summary>
+    [Fact]
+    public void SerialTransport_DisconnectSetsNotConnected()
+    {
+        using var transport = new SerialTransportService();
+
+        // Not connected to begin with
+        transport.Disconnect();
+        Assert.False(transport.IsConnected);
+        Assert.Null(transport.ConnectionLabel);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="SerialTransportService.Send(string)"/>
+    /// after <see cref="SerialTransportService.Disconnect"/> is a safe no-op.
+    /// </summary>
+    [Fact]
+    public void SerialTransport_SendAfterDisconnect_NoOp()
+    {
+        using var transport = new SerialTransportService();
+        string? error = null;
+        transport.ErrorOccurred += msg => error = msg;
+
+        transport.Disconnect();
+        transport.Send("L0500I1000\n");
+        transport.Send(System.Text.Encoding.UTF8.GetBytes("L0500I1000\n"));
+
+        // No error should have been raised — send should be a quiet no-op
+        Assert.Null(error);
+    }
 }


### PR DESCRIPTION
…d safety

- Resolved race condition causing application freeze when using Serial transport with Pulse.
- Implemented asynchronous port closure in Disconnect() to avoid UI blocking.
- Introduced _sendLock to serialize concurrent serial writes.
- Updated HomeAxes(), SendMidpoint(), and SendPositionWithOffset() to enqueue commands via the output thread.
- Increased StopTimer() join timeout to 1500ms to prevent indefinite UI blocking.
- Added tests for concurrent Send calls and safe disconnect behavior.