### PR TITLE
fix(transport): resolve application freeze with empty L0 script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Vido project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **VI-0012**: Fixed application freeze when using Serial transport with Pulse and no funscript by injecting an empty L0 funscript when Pulse suppresses funscript auto-loading. This ensures `TCodeService` always has a valid script entry during Pulse+Serial playback, routing through the safe interpolation path instead of the fill-mode code path that could trigger a race condition.
 - **VI-0009**: Fixed critical application freeze when using Serial transport with Pulse (no funscript). Root cause was a race condition between `SerialPort.Close()` on the UI thread and `BaseStream.Write()` on the TCode output thread. `Disconnect()` now closes the port asynchronously on a ThreadPool thread. Added `_sendLock` to serialize concurrent serial writes. `HomeAxes()`, `SendMidpoint()`, and `SendPositionWithOffset()` now enqueue commands via the output thread instead of calling `_transport.Send()` directly from the UI thread. `StopTimer()` join timeout increased from 500ms to 1500ms with a non-blocking fallback.
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- App version -->
-    <VidoVersion>0.16.0</VidoVersion>
+    <VidoVersion>0.17.0</VidoVersion>
     <Company>Vido</Company>
     <Product>Vido</Product>
     <Authors>Vido</Authors>

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1673,9 +1673,18 @@ public partial class MainWindow : Window
         {
             _axisControlVm.OnSuppressFunscript(evt);
 
-            // When switching back to funscript, show the Funscript Visualizer
-            if (!evt.SuppressFunscripts)
+            if (evt.SuppressFunscripts)
             {
+                // Inject an empty L0 funscript so TCodeService always has a valid
+                // script entry during Pulse+Serial — prevents output-loop freeze.
+                _tcode?.SetScripts(new Dictionary<string, FunscriptData>
+                {
+                    ["L0"] = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] }
+                });
+            }
+            else
+            {
+                // When switching back to funscript, show the Funscript Visualizer
                 _mainWindowViewModel.ActivateBottomPanelTab("osr2.visualizer");
                 if (_bottomPanelContents.TryGetValue("osr2.visualizer", out var content))
                     BottomPanelContent.Content = content;

--- a/tests/Vido.Tests/Osr2ViewModelTests.cs
+++ b/tests/Vido.Tests/Osr2ViewModelTests.cs
@@ -533,6 +533,38 @@ public class Osr2ViewModelTests : IDisposable
     }
 
     /// <summary>
+    /// Verifies that after OnSuppressFunscript clears scripts, an empty L0 script
+    /// can be injected on TCodeService to prevent Serial freeze (VI-0012).
+    /// </summary>
+    [Fact]
+    public void AxisControl_SuppressThenEmptyL0Injection_HasScriptsLoaded()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+
+        // Load initial scripts
+        var script = MakeScript((0, 0), (1000, 100));
+        vm.FindMatchingScriptsFunc = _ => new Dictionary<string, string>
+        {
+            { "L0", @"C:\videos\test.L0.funscript" }
+        };
+        vm.TryParseMultiAxisFunc = _ => null;
+        vm.ParseFileFunc = (_, _) => script;
+        vm.LoadScriptsForVideo(@"C:\videos\test.mp4");
+        Assert.True(_tcode.HasScriptsLoaded);
+
+        // Suppress — ClearAllScripts leaves TCode with zero scripts
+        vm.OnSuppressFunscript(new SuppressFunscriptEvent { SuppressFunscripts = true });
+        Assert.False(_tcode.HasScriptsLoaded);
+
+        // Inject empty L0 (simulates MainWindow handler, VI-0012)
+        _tcode.SetScripts(new Dictionary<string, FunscriptData>
+        {
+            ["L0"] = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] }
+        });
+        Assert.True(_tcode.HasScriptsLoaded);
+    }
+
+    /// <summary>
     /// Verifies that SetVideoPlaying updates IsTestEnabled.
     /// </summary>
     [Fact]

--- a/tests/Vido.Tests/TCodeEngineTests.cs
+++ b/tests/Vido.Tests/TCodeEngineTests.cs
@@ -393,6 +393,70 @@ public class TCodeEngineTests : IDisposable
         Assert.False(_service.HasScriptsLoaded);
     }
 
+    /// <summary>
+    /// Verifies that SetScripts with an empty-actions FunscriptData for L0
+    /// is accepted and reports scripts as loaded (VI-0012).
+    /// </summary>
+    [Fact]
+    public void SetScripts_EmptyActionsL0_HasScriptsLoadedTrue()
+    {
+        var emptyScript = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] };
+
+        _service.SetScripts(new Dictionary<string, FunscriptData>
+        {
+            ["L0"] = emptyScript
+        });
+
+        Assert.True(_service.HasScriptsLoaded);
+    }
+
+    /// <summary>
+    /// Verifies that interpolation returns midpoint (50) for an empty-actions script,
+    /// preventing NullReferenceException or freeze in the output loop (VI-0012).
+    /// </summary>
+    [Fact]
+    public void SetScripts_EmptyActionsL0_InterpolatesWithoutError()
+    {
+        var emptyScript = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] };
+        _service.SetScripts(new Dictionary<string, FunscriptData>
+        {
+            ["L0"] = emptyScript
+        });
+        _service.SetAxisConfigs([MakeL0()]);
+        _service.SetPlaying(true);
+        _service.SetTime(1000);
+
+        // IsFunscriptPlaying should be true — the output loop will use the
+        // empty script and interpolation returns 50.0, avoiding the freeze path.
+        Assert.True(_service.IsFunscriptPlaying);
+    }
+
+    /// <summary>
+    /// Verifies that re-setting scripts after clearing with an empty-actions L0
+    /// replaces the prior state correctly (simulates Pulse suppress flow, VI-0012).
+    /// </summary>
+    [Fact]
+    public void SetScripts_ClearThenEmptyL0_ReplacesPriorState()
+    {
+        // Load a real script
+        _service.SetScripts(new Dictionary<string, FunscriptData>
+        {
+            ["L0"] = MakeScript((0, 0), (1000, 100))
+        });
+        Assert.True(_service.HasScriptsLoaded);
+
+        // Clear (simulates ClearAllScripts)
+        _service.SetScripts(new Dictionary<string, FunscriptData>());
+        Assert.False(_service.HasScriptsLoaded);
+
+        // Re-set with empty L0 (simulates empty funscript injection)
+        _service.SetScripts(new Dictionary<string, FunscriptData>
+        {
+            ["L0"] = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] }
+        });
+        Assert.True(_service.HasScriptsLoaded);
+    }
+
     // ═══════════════════════════════════════════════
     //  SetTime / GetExtrapolatedTimeMs
     // ═══════════════════════════════════════════════


### PR DESCRIPTION
* Fixed application freeze when using Serial transport with Pulse and no funscript by injecting an empty L0 funscript.
* Ensured TCodeService always has a valid script entry during Pulse+Serial playback.
* Updated tests to verify behavior with empty L0 script injection.