### PR TITLE
feat(funscript): VI-0023 add amplitude-aware funscript generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Vido project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **VI-0023**: Fixed generated funscripts from Pulse using fixed 0/100 positions instead of matching the audio waveform amplitude. New `CreateActionsFromBeatMap(BeatMap)` method in `FunscriptWriter` replicates `PulseTCodeMapper`'s amplitude-aware position formula — sampling `BeatMap.WaveformSamples` at each beat timestamp and scaling stroke range by `amplitudeScale * (0.5 + 0.5 * beatStrength)`. `PulseSidebarViewModel.GenerateFunscriptAsync` now calls the new overload. Original `CreateActionsFromBeats` preserved for backward compatibility.
 - **VI-0022**: Fixed SyncWithStroke fill modes (R0/R1/R2) getting stuck at a fixed position when switching from funscript to Pulse mode. The empty L0 script injected by VI-0012 was winning the stroke tracking priority check in `OutputTick`, causing `_cumulativeStrokeDistance` to never accumulate. Swapped priority so external positions (Pulse) are checked before scripts for stroke tracking.
 - **VI-0021**: Fixed bottom panel appearing over fullscreen video when the next video auto-plays and scripts load. `ActivateBottomPanelTab`, `OpenBottomPanelTab`, `ToggleBottomPanel`, and `ToggleBottomPanelCollapse` now guard `IsBottomPanelVisible = true` with `if (!IsFullscreen)`. The active tab is still set correctly so the right tab is visible when exiting fullscreen.
 

--- a/src/Vido.Services/Osr2Plus/FunscriptWriter.cs
+++ b/src/Vido.Services/Osr2Plus/FunscriptWriter.cs
@@ -33,6 +33,71 @@ public static class FunscriptWriter
     }
 
     /// <summary>
+    /// Converts a beat map into amplitude-aware funscript actions.
+    /// Replicates PulseTCodeMapper's intensity formula: at each beat, the
+    /// waveform amplitude is sampled from <see cref="BeatMap.WaveformSamples"/>
+    /// and combined with <see cref="BeatEvent.Strength"/> to scale the stroke range.
+    /// Even-indexed beats produce upstroke (top) positions, odd-indexed beats
+    /// produce downstroke (bottom) positions.
+    /// </summary>
+    /// <param name="beatMap">Beat map containing beats, waveform samples, and sample rate.</param>
+    /// <returns>List of amplitude-scaled funscript actions.</returns>
+    public static List<FunscriptAction> CreateActionsFromBeatMap(BeatMap beatMap)
+    {
+        const double MinPosition = 5.0;
+        const double MaxPosition = 95.0;
+        const double RestPosition = 50.0;
+        const double MinAmplitudeScale = 0.15;
+
+        var beats = beatMap.Beats;
+        var actions = new List<FunscriptAction>(beats.Count);
+        if (beats.Count == 0) return actions;
+
+        var waveform = beatMap.WaveformSamples;
+        int sampleRate = beatMap.WaveformSampleRate;
+
+        for (int i = 0; i < beats.Count; i++)
+        {
+            var beat = beats[i];
+            double beatStrength = Math.Clamp(beat.Strength, 0.0, 1.0);
+
+            // Sample amplitude from the pre-computed waveform envelope
+            double amplitude = SampleWaveformAmplitude(waveform, sampleRate, beat.TimestampMs);
+
+            // Replicate PulseTCodeMapper intensity formula
+            double amplitudeScale = MinAmplitudeScale + (1.0 - MinAmplitudeScale) * amplitude;
+            double intensityScale = amplitudeScale * (0.5 + 0.5 * beatStrength);
+
+            double halfRange = (MaxPosition - MinPosition) / 2.0 * intensityScale;
+            double top = Math.Min(RestPosition + halfRange, MaxPosition);
+            double bottom = Math.Max(RestPosition - halfRange, MinPosition);
+
+            // Even beats → top (upstroke peak), odd beats → bottom (downstroke trough)
+            double position = (i % 2 == 0) ? top : bottom;
+            actions.Add(new FunscriptAction((long)beat.TimestampMs, (int)Math.Round(position)));
+        }
+
+        return actions;
+    }
+
+    /// <summary>
+    /// Samples the pre-computed waveform amplitude at the given timestamp.
+    /// Returns 0.0 if waveform data is empty or the timestamp is out of range.
+    /// </summary>
+    internal static double SampleWaveformAmplitude(
+        IReadOnlyList<float> waveformSamples, int sampleRate, double timestampMs)
+    {
+        if (waveformSamples == null || waveformSamples.Count == 0 || sampleRate <= 0)
+            return 0.0;
+
+        int index = (int)(timestampMs / 1000.0 * sampleRate);
+        if (index < 0) return 0.0;
+        if (index >= waveformSamples.Count) return 0.0;
+
+        return Math.Clamp(waveformSamples[index], 0f, 1f);
+    }
+
+    /// <summary>
     /// Serializes funscript actions to a standard .funscript JSON string.
     /// Output format: <c>{"version":"1.0","actions":[{"at":1250,"pos":100},...]}</c>.
     /// </summary>

--- a/src/Vido.ViewModels/Pulse/PulseSidebarViewModel.cs
+++ b/src/Vido.ViewModels/Pulse/PulseSidebarViewModel.cs
@@ -268,7 +268,7 @@ internal sealed class PulseSidebarViewModel : INotifyPropertyChanged, IDisposabl
         OnPropertyChanged(nameof(CanGenerateFunscript));
         try
         {
-            var actions = FunscriptWriter.CreateActionsFromBeats(beatMap.Beats);
+            var actions = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
             await FunscriptWriter.WriteAsync(actions, targetPath);
             _toastService?.Show("Funscript generated:", fileName);
             _eventBus.Publish(new FunscriptGeneratedEvent

--- a/tests/Vido.Tests/FunscriptWriterTests.cs
+++ b/tests/Vido.Tests/FunscriptWriterTests.cs
@@ -190,4 +190,208 @@ public class FunscriptWriterTests : IDisposable
         Assert.True(Directory.Exists(subDir));
         Assert.True(File.Exists(filePath));
     }
+
+    // ══════════════════════════════════════════════
+    //  CreateActionsFromBeatMap (VI-0023)
+    // ══════════════════════════════════════════════
+
+    private static BeatMap MakeBeatMap(
+        IReadOnlyList<BeatEvent> beats,
+        float[]? waveformSamples = null,
+        int waveformSampleRate = 100,
+        double bpm = 120,
+        double durationMs = 10000)
+    {
+        return new BeatMap
+        {
+            Beats = beats,
+            WaveformSamples = waveformSamples ?? Array.Empty<float>(),
+            WaveformSampleRate = waveformSampleRate,
+            Bpm = bpm,
+            DurationMs = durationMs
+        };
+    }
+
+    [Fact]
+    public void CreateActionsFromBeatMap_EmptyBeats_ReturnsEmptyList()
+    {
+        var beatMap = MakeBeatMap([]);
+        var result = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void CreateActionsFromBeatMap_AlternatesTopBottom()
+    {
+        // Full amplitude (1.0) and full strength (1.0) → positions near 5 and 95
+        var waveform = new float[] { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f };
+        var beats = new List<BeatEvent>
+        {
+            new() { TimestampMs = 0, Strength = 1.0 },
+            new() { TimestampMs = 10, Strength = 1.0 },
+            new() { TimestampMs = 20, Strength = 1.0 },
+            new() { TimestampMs = 30, Strength = 1.0 },
+        };
+        var beatMap = MakeBeatMap(beats, waveform);
+
+        var result = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+
+        Assert.Equal(4, result.Count);
+        // Even beats → top (> 50), odd beats → bottom (< 50)
+        Assert.True(result[0].Pos > 50, $"Even beat should be top, was {result[0].Pos}");
+        Assert.True(result[1].Pos < 50, $"Odd beat should be bottom, was {result[1].Pos}");
+        Assert.True(result[2].Pos > 50, $"Even beat should be top, was {result[2].Pos}");
+        Assert.True(result[3].Pos < 50, $"Odd beat should be bottom, was {result[3].Pos}");
+    }
+
+    [Fact]
+    public void CreateActionsFromBeatMap_ScalesWithAmplitude()
+    {
+        // High amplitude beat vs low amplitude beat — both with same strength
+        // Waveform: index 0 = 1.0 (loud), index 1 = 0.1 (quiet)
+        // SampleRate=100 → index = timestampMs / 1000 * 100 = timestampMs / 10
+        // Beat at 0ms → index 0 (1.0), beat at 10ms → index 1 (0.1)
+        var waveform = new float[] { 1.0f, 0.1f };
+        var beats = new List<BeatEvent>
+        {
+            new() { TimestampMs = 0, Strength = 1.0 },   // high amplitude → wide range
+            new() { TimestampMs = 10, Strength = 1.0 },   // low amplitude → narrow range
+        };
+        var beatMap = MakeBeatMap(beats, waveform);
+
+        var result = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+
+        // High amplitude beat (even) should be further from 50 than low amplitude beat (odd from center)
+        // With amplitude=1.0: amplitudeScale = 0.15 + 0.85*1.0 = 1.0, intensityScale = 1.0 * 1.0 = 1.0
+        //   halfRange = 45*1.0 = 45, top = 95
+        // With amplitude=0.1: amplitudeScale = 0.15 + 0.85*0.1 = 0.235, intensityScale = 0.235 * 1.0 = 0.235
+        //   halfRange = 45*0.235 = 10.575, bottom = 50 - 10.575 = 39.4 → 39
+        int highAmpTop = result[0].Pos;  // even, high amplitude
+        int lowAmpBottom = result[1].Pos;  // odd, low amplitude
+
+        Assert.Equal(95, highAmpTop);  // Full amplitude → max position
+        Assert.True(lowAmpBottom > 35 && lowAmpBottom < 50,
+            $"Low amplitude bottom should be closer to 50, was {lowAmpBottom}");
+    }
+
+    [Fact]
+    public void CreateActionsFromBeatMap_ScalesWithBeatStrength()
+    {
+        // Same amplitude (1.0), different beat strength
+        var waveform = new float[] { 1.0f, 1.0f, 1.0f };
+        var beats = new List<BeatEvent>
+        {
+            new() { TimestampMs = 0, Strength = 1.0 },   // strong beat → wide range
+            new() { TimestampMs = 10, Strength = 0.0 },   // weak beat → narrower range
+        };
+        var beatMap = MakeBeatMap(beats, waveform);
+
+        var result = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+
+        // Strength=1.0: intensityScale = 1.0 * (0.5 + 0.5) = 1.0, halfRange=45, top=95
+        // Strength=0.0: intensityScale = 1.0 * (0.5 + 0.0) = 0.5, halfRange=22.5, bottom=50-22.5=27.5→28
+        int strongTop = result[0].Pos;
+        int weakBottom = result[1].Pos;
+
+        Assert.Equal(95, strongTop);
+        // Weak beat (odd) should be closer to 50 than a strong beat would be
+        Assert.True(weakBottom > 20 && weakBottom < 40,
+            $"Weak beat bottom should be closer to center, was {weakBottom}");
+    }
+
+    [Fact]
+    public void CreateActionsFromBeatMap_EmptyWaveform_UsesMinAmplitude()
+    {
+        // No waveform data → amplitude = 0.0 → MinAmplitudeScale (0.15)
+        var beats = new List<BeatEvent>
+        {
+            new() { TimestampMs = 0, Strength = 1.0 },
+            new() { TimestampMs = 500, Strength = 1.0 },
+        };
+        var beatMap = MakeBeatMap(beats);  // empty waveform
+
+        var result = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+
+        Assert.Equal(2, result.Count);
+        // amplitude=0.0: amplitudeScale=0.15, intensityScale=0.15*1.0=0.15
+        // halfRange=45*0.15=6.75, top=56.75→57, bottom=43.25→43
+        Assert.True(result[0].Pos > 50 && result[0].Pos < 65,
+            $"Min amplitude top should be just above center, was {result[0].Pos}");
+        Assert.True(result[1].Pos > 35 && result[1].Pos < 50,
+            $"Min amplitude bottom should be just below center, was {result[1].Pos}");
+    }
+
+    [Fact]
+    public void CreateActionsFromBeatMap_PositionsWithinBounds()
+    {
+        // Various amplitudes and strengths — all positions must be within 5–95
+        var waveform = new float[200];
+        for (int i = 0; i < waveform.Length; i++)
+            waveform[i] = (float)(i % 10) / 10f;
+
+        var beats = new List<BeatEvent>();
+        for (int i = 0; i < 20; i++)
+            beats.Add(new BeatEvent { TimestampMs = i * 100, Strength = i / 20.0 });
+
+        var beatMap = MakeBeatMap(beats, waveform);
+
+        var result = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+
+        Assert.Equal(20, result.Count);
+        foreach (var action in result)
+        {
+            Assert.InRange(action.Pos, 5, 95);
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    //  SampleWaveformAmplitude (VI-0023)
+    // ══════════════════════════════════════════════
+
+    [Fact]
+    public void SampleWaveformAmplitude_ValidIndex_ReturnsCorrectValue()
+    {
+        // SampleRate=100 → 100 samples/sec → index = timestampMs / 1000 * 100 = timestampMs / 10
+        var waveform = new float[] { 0.1f, 0.5f, 0.9f };
+        var result = FunscriptWriter.SampleWaveformAmplitude(waveform, 100, 10.0);
+        Assert.Equal(0.5, result, 3);
+    }
+
+    [Fact]
+    public void SampleWaveformAmplitude_OutOfRange_ReturnsZero()
+    {
+        var waveform = new float[] { 0.5f, 0.8f };
+        var result = FunscriptWriter.SampleWaveformAmplitude(waveform, 100, 5000.0);
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void SampleWaveformAmplitude_EmptyWaveform_ReturnsZero()
+    {
+        var result = FunscriptWriter.SampleWaveformAmplitude(Array.Empty<float>(), 100, 0.0);
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void SampleWaveformAmplitude_NullWaveform_ReturnsZero()
+    {
+        var result = FunscriptWriter.SampleWaveformAmplitude(null!, 100, 0.0);
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void SampleWaveformAmplitude_ZeroSampleRate_ReturnsZero()
+    {
+        var waveform = new float[] { 0.5f };
+        var result = FunscriptWriter.SampleWaveformAmplitude(waveform, 0, 0.0);
+        Assert.Equal(0.0, result);
+    }
+
+    [Fact]
+    public void SampleWaveformAmplitude_ClampsAboveOne()
+    {
+        var waveform = new float[] { 1.5f };
+        var result = FunscriptWriter.SampleWaveformAmplitude(waveform, 100, 0.0);
+        Assert.Equal(1.0, result);
+    }
 }


### PR DESCRIPTION
* Implement CreateActionsFromBeatMap method to generate funscript actions based on audio waveform amplitude.
* Update PulseSidebarViewModel to utilize the new method for generating funscripts.
* Enhance unit tests for CreateActionsFromBeatMap and SampleWaveformAmplitude to ensure correct functionality.