### PR TITLE
feat(pulse): VI-0024 add beat rate selector for funscript generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **VI-0024**: Added beat rate selector ComboBox to the Pulse sidebar, placed to the left of the "Generate Funscript" button. Offers the same four options as the beat bar rate selector ("Every Beat" through "Every 4th Beat") but is independent from live playback beat rate. New `FilterBeatsByDivisor` method in `FunscriptWriter` filters the raw beat map before generation. Setting persisted as `PulseFunscriptBeatRateIndex` in `AppSettings`.
+
 ### Fixed
 - **VI-0023**: Fixed generated funscripts from Pulse using fixed 0/100 positions instead of matching the audio waveform amplitude. New `CreateActionsFromBeatMap(BeatMap)` method in `FunscriptWriter` replicates `PulseTCodeMapper`'s amplitude-aware position formula — sampling `BeatMap.WaveformSamples` at each beat timestamp and scaling stroke range by `amplitudeScale * (0.5 + 0.5 * beatStrength)`. `PulseSidebarViewModel.GenerateFunscriptAsync` now calls the new overload. Original `CreateActionsFromBeats` preserved for backward compatibility.
 - **VI-0022**: Fixed SyncWithStroke fill modes (R0/R1/R2) getting stuck at a fixed position when switching from funscript to Pulse mode. The empty L0 script injected by VI-0012 was winning the stroke tracking priority check in `OutputTick`, causing `_cumulativeStrokeDistance` to never accumulate. Swapped priority so external positions (Pulse) are checked before scripts for stroke tracking.

--- a/src/Vido.Core/Settings/AppSettings.cs
+++ b/src/Vido.Core/Settings/AppSettings.cs
@@ -203,6 +203,11 @@ public sealed class AppSettings
     /// </summary>
     public int PulseBeatRateIndex { get; set; } = 0;
 
+    /// <summary>
+    /// Index of the selected beat rate for funscript generation (independent from live beat rate).
+    /// </summary>
+    public int PulseFunscriptBeatRateIndex { get; set; } = 0;
+
     // --- General ---
 
     /// <summary>
@@ -288,6 +293,7 @@ public sealed class AppSettings
         PulseWaveformWindowDuration = 30;
         PulseUsePulse = false;
         PulseBeatRateIndex = 0;
+        PulseFunscriptBeatRateIndex = 0;
 
         // General settings
         ToastDurationSeconds = 3.0;

--- a/src/Vido.Services/Osr2Plus/FunscriptWriter.cs
+++ b/src/Vido.Services/Osr2Plus/FunscriptWriter.cs
@@ -81,6 +81,34 @@ public static class FunscriptWriter
     }
 
     /// <summary>
+    /// Filters a beat map by taking every Nth beat, where N is the divisor.
+    /// Replicates <c>PulseEngine.RebuildEffectiveBeatMap</c> logic.
+    /// If <paramref name="divisor"/> is 1 or less, returns the input unchanged.
+    /// </summary>
+    /// <param name="beatMap">The beat map to filter.</param>
+    /// <param name="divisor">Beat divisor: 1 = every beat, 2 = every other, 3 = every 3rd, 4 = every 4th.</param>
+    /// <returns>A filtered beat map with scaled BPM and preserved waveform data.</returns>
+    public static BeatMap FilterBeatsByDivisor(BeatMap beatMap, int divisor)
+    {
+        if (divisor <= 1) return beatMap;
+
+        var beats = beatMap.Beats;
+        var filtered = new List<BeatEvent>();
+        for (int i = 0; i < beats.Count; i += divisor)
+            filtered.Add(beats[i]);
+
+        return new BeatMap
+        {
+            Beats = filtered,
+            Bpm = beatMap.Bpm / divisor,
+            BpmConfidence = beatMap.BpmConfidence,
+            DurationMs = beatMap.DurationMs,
+            WaveformSamples = beatMap.WaveformSamples,
+            WaveformSampleRate = beatMap.WaveformSampleRate
+        };
+    }
+
+    /// <summary>
     /// Samples the pre-computed waveform amplitude at the given timestamp.
     /// Returns 0.0 if waveform data is empty or the timestamp is out of range.
     /// </summary>

--- a/src/Vido.ViewModels/Pulse/PulseSidebarViewModel.cs
+++ b/src/Vido.ViewModels/Pulse/PulseSidebarViewModel.cs
@@ -33,6 +33,7 @@ internal sealed class PulseSidebarViewModel : INotifyPropertyChanged, IDisposabl
     private string _statusBarText = "\u2665 Pulse: Off";
     private string? _errorMessage;
     private int _selectedBeatRateIndex;
+    private int _selectedFunscriptBeatRateIndex;
     private bool _disposed;
     private string? _currentVideoPath;
     private bool _isGenerating;
@@ -66,6 +67,7 @@ internal sealed class PulseSidebarViewModel : INotifyPropertyChanged, IDisposabl
         // Load persisted state
         _usePulse = _settingsService.Current.PulseUsePulse;
         _selectedBeatRateIndex = _settingsService.Current.PulseBeatRateIndex;
+        _selectedFunscriptBeatRateIndex = _settingsService.Current.PulseFunscriptBeatRateIndex;
         _state = _engine.State;
 
         _engine.StateChanged += OnEngineStateChanged;
@@ -218,6 +220,23 @@ internal sealed class PulseSidebarViewModel : INotifyPropertyChanged, IDisposabl
         }
     }
 
+    /// <summary>
+    /// Selected beat rate index for funscript generation (0 = every beat, 1 = every 2nd, etc.).
+    /// Independent from the live playback beat rate.
+    /// </summary>
+    public int SelectedFunscriptBeatRateIndex
+    {
+        get => _selectedFunscriptBeatRateIndex;
+        set
+        {
+            if (_selectedFunscriptBeatRateIndex == value) return;
+            _selectedFunscriptBeatRateIndex = value;
+            OnPropertyChanged();
+            _settingsService.Current.PulseFunscriptBeatRateIndex = value;
+            _settingsService.QueueSave();
+        }
+    }
+
     /// <summary>Description text explaining Pulse behaviour.</summary>
     public string Description =>
         "When Use Pulse is enabled:\n" +
@@ -227,6 +246,10 @@ internal sealed class PulseSidebarViewModel : INotifyPropertyChanged, IDisposabl
         "\u2022 L0 axis is driven by beat-synchronized strokes\n" +
         "\u2022 Other axes (R0/R1/R2) continue with fill modes\n" +
         "\u2022 OSR2+ axis Min/Max/Enabled settings still apply\n\n" +
+        "Generate Funscript:\n" +
+        "Use the beat rate selector to choose which beats are included (Every Beat, Every 2nd/3rd/4th Beat), " +
+        "then click Generate Funscript to create a .funscript file. " +
+        "The generated script mirrors the Pulse waveform amplitude, producing strokes that match the audio intensity.\n\n" +
         "Toggle off to restore normal funscript behavior.";
 
     // ── Generate Funscript ──
@@ -268,7 +291,9 @@ internal sealed class PulseSidebarViewModel : INotifyPropertyChanged, IDisposabl
         OnPropertyChanged(nameof(CanGenerateFunscript));
         try
         {
-            var actions = FunscriptWriter.CreateActionsFromBeatMap(beatMap);
+            int divisor = _selectedFunscriptBeatRateIndex + 1;
+            var filteredBeatMap = FunscriptWriter.FilterBeatsByDivisor(beatMap, divisor);
+            var actions = FunscriptWriter.CreateActionsFromBeatMap(filteredBeatMap);
             await FunscriptWriter.WriteAsync(actions, targetPath);
             _toastService?.Show("Funscript generated:", fileName);
             _eventBus.Publish(new FunscriptGeneratedEvent

--- a/src/Vido.Views/Pulse/PulseSidebarView.xaml
+++ b/src/Vido.Views/Pulse/PulseSidebarView.xaml
@@ -14,6 +14,42 @@
             <BooleanToVisibilityConverter x:Key="BoolToVis" />
             <converters:StateColorToBrushConverter x:Key="StateColorBrush" />
             <converters:FractionToPercentConverter x:Key="FracToPercent" />
+
+            <Style x:Key="GenerateFunscriptButtonStyle" TargetType="Button">
+                <Setter Property="Background" Value="#2D2D2D" />
+                <Setter Property="Foreground" Value="#CCCCCC" />
+                <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Padding" Value="8,5" />
+                <Setter Property="FontSize" Value="11" />
+                <Setter Property="FontFamily" Value="Segoe UI" />
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="SnapsToDevicePixels" Value="True" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Border"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    Padding="{TemplateBinding Padding}"
+                                    SnapsToDevicePixels="True">
+                                <ContentPresenter HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center" />
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="Border" Property="Background"
+                                            Value="{DynamicResource AccentBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled" Value="False">
+                                    <Setter TargetName="Border" Property="Opacity" Value="0.4" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -87,19 +123,29 @@
             </StackPanel>
 
             <!-- ════ Generate Funscript ════ -->
-            <Button Content="Generate Funscript"
-                    Command="{Binding GenerateFunscriptCommand}"
-                    IsEnabled="{Binding CanGenerateFunscript}"
-                    Visibility="{Binding ShowBpm, Converter={StaticResource BoolToVis}}"
-                    Margin="0,0,0,8"
-                    Padding="8,5"
-                    HorizontalAlignment="Stretch"
-                    Background="#2D2D2D"
-                    Foreground="#CCCCCC"
-                    BorderBrush="{StaticResource BorderBrush}"
-                    BorderThickness="1"
-                    FontSize="11" FontFamily="Segoe UI"
-                    ToolTip="Generate a .funscript file from the detected beats" />
+            <Grid Visibility="{Binding ShowBpm, Converter={StaticResource BoolToVis}}"
+                  Margin="0,0,0,8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="8" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <ComboBox Grid.Column="0"
+                          Style="{StaticResource PulseComboBoxStyle}"
+                          ItemContainerStyle="{StaticResource PulseComboBoxItemStyle}"
+                          ItemsSource="{Binding BeatRateOptions}"
+                          SelectedIndex="{Binding SelectedFunscriptBeatRateIndex, Mode=TwoWay}"
+                          VerticalAlignment="Stretch"
+                          ToolTip="Beat rate for generated funscript" />
+
+                <Button Grid.Column="2"
+                        Content="Generate Funscript"
+                        Style="{StaticResource GenerateFunscriptButtonStyle}"
+                        Command="{Binding GenerateFunscriptCommand}"
+                        IsEnabled="{Binding CanGenerateFunscript}"
+                        ToolTip="Generate a .funscript file from the detected beats" />
+            </Grid>
 
             <!-- ════ Separator ════ -->
             <Border Height="1"

--- a/tests/Vido.Tests/FunscriptWriterTests.cs
+++ b/tests/Vido.Tests/FunscriptWriterTests.cs
@@ -394,4 +394,95 @@ public class FunscriptWriterTests : IDisposable
         var result = FunscriptWriter.SampleWaveformAmplitude(waveform, 100, 0.0);
         Assert.Equal(1.0, result);
     }
+
+    // ══════════════════════════════════════════════
+    //  FilterBeatsByDivisor (VI-0024)
+    // ══════════════════════════════════════════════
+
+    [Fact]
+    public void FilterBeatsByDivisor_Divisor1_ReturnsSameBeatMap()
+    {
+        var beatMap = MakeBeatMap(
+            Enumerable.Range(0, 10).Select(i => new BeatEvent { TimestampMs = i * 500, Strength = 0.8 }).ToList(),
+            new float[] { 0.5f, 0.6f, 0.7f }, waveformSampleRate: 100, bpm: 120);
+
+        var result = FunscriptWriter.FilterBeatsByDivisor(beatMap, 1);
+
+        Assert.Same(beatMap, result);
+    }
+
+    [Fact]
+    public void FilterBeatsByDivisor_Divisor2_TakesEveryOtherBeat()
+    {
+        var beats = Enumerable.Range(0, 10)
+            .Select(i => new BeatEvent { TimestampMs = i * 500, Strength = 0.8 }).ToList();
+        var beatMap = MakeBeatMap(beats, new float[] { 0.5f }, waveformSampleRate: 100, bpm: 120);
+
+        var result = FunscriptWriter.FilterBeatsByDivisor(beatMap, 2);
+
+        Assert.Equal(5, result.Beats.Count);
+        Assert.Equal(0, result.Beats[0].TimestampMs);
+        Assert.Equal(1000, result.Beats[1].TimestampMs);
+        Assert.Equal(2000, result.Beats[2].TimestampMs);
+        Assert.Equal(3000, result.Beats[3].TimestampMs);
+        Assert.Equal(4000, result.Beats[4].TimestampMs);
+        Assert.Equal(60.0, result.Bpm);
+    }
+
+    [Fact]
+    public void FilterBeatsByDivisor_Divisor3_TakesEveryThirdBeat()
+    {
+        var beats = Enumerable.Range(0, 9)
+            .Select(i => new BeatEvent { TimestampMs = i * 500, Strength = 0.8 }).ToList();
+        var beatMap = MakeBeatMap(beats, new float[] { 0.5f }, waveformSampleRate: 100, bpm: 120);
+
+        var result = FunscriptWriter.FilterBeatsByDivisor(beatMap, 3);
+
+        Assert.Equal(3, result.Beats.Count);
+        Assert.Equal(0, result.Beats[0].TimestampMs);
+        Assert.Equal(1500, result.Beats[1].TimestampMs);
+        Assert.Equal(3000, result.Beats[2].TimestampMs);
+        Assert.Equal(40.0, result.Bpm);
+    }
+
+    [Fact]
+    public void FilterBeatsByDivisor_Divisor4_TakesEveryFourthBeat()
+    {
+        var beats = Enumerable.Range(0, 12)
+            .Select(i => new BeatEvent { TimestampMs = i * 500, Strength = 0.8 }).ToList();
+        var beatMap = MakeBeatMap(beats, new float[] { 0.5f }, waveformSampleRate: 100, bpm: 120);
+
+        var result = FunscriptWriter.FilterBeatsByDivisor(beatMap, 4);
+
+        Assert.Equal(3, result.Beats.Count);
+        Assert.Equal(0, result.Beats[0].TimestampMs);
+        Assert.Equal(2000, result.Beats[1].TimestampMs);
+        Assert.Equal(4000, result.Beats[2].TimestampMs);
+        Assert.Equal(30.0, result.Bpm);
+    }
+
+    [Fact]
+    public void FilterBeatsByDivisor_EmptyBeats_ReturnsEmptyBeats()
+    {
+        var beatMap = MakeBeatMap(new List<BeatEvent>(), new float[] { 0.5f }, waveformSampleRate: 100, bpm: 120);
+
+        var result = FunscriptWriter.FilterBeatsByDivisor(beatMap, 2);
+
+        Assert.Empty(result.Beats);
+    }
+
+    [Fact]
+    public void FilterBeatsByDivisor_PreservesWaveformData()
+    {
+        var waveform = new float[] { 0.1f, 0.5f, 0.9f };
+        var beats = Enumerable.Range(0, 6)
+            .Select(i => new BeatEvent { TimestampMs = i * 500, Strength = 0.8 }).ToList();
+        var beatMap = MakeBeatMap(beats, waveform, waveformSampleRate: 44100, bpm: 120);
+
+        var result = FunscriptWriter.FilterBeatsByDivisor(beatMap, 2);
+
+        Assert.Same(waveform, result.WaveformSamples);
+        Assert.Equal(44100, result.WaveformSampleRate);
+        Assert.Equal(beatMap.DurationMs, result.DurationMs);
+    }
 }

--- a/tests/Vido.Tests/PulseSidebarViewModelTests.cs
+++ b/tests/Vido.Tests/PulseSidebarViewModelTests.cs
@@ -315,6 +315,68 @@ public class PulseSidebarViewModelTests : IDisposable
     }
 
     // ══════════════════════════════════════════════
+    //  Funscript Beat Rate Selector (VI-0024)
+    // ══════════════════════════════════════════════
+
+    [Fact]
+    public void SelectedFunscriptBeatRateIndex_DefaultsFromSettings()
+    {
+        _settings.PulseFunscriptBeatRateIndex = 2;
+        using var vm = new PulseSidebarViewModel(_engine, _settingsService, _eventBus, _toastService);
+
+        Assert.Equal(2, vm.SelectedFunscriptBeatRateIndex);
+    }
+
+    [Fact]
+    public void SelectedFunscriptBeatRateIndex_PersistsToSettings()
+    {
+        using var vm = new PulseSidebarViewModel(_engine, _settingsService, _eventBus, _toastService);
+
+        vm.SelectedFunscriptBeatRateIndex = 3;
+
+        Assert.Equal(3, _settings.PulseFunscriptBeatRateIndex);
+        _settingsService.Received().QueueSave();
+    }
+
+    [Fact]
+    public async Task GenerateFunscript_WithBeatRate2_GeneratesFilteredFunscript()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "vido_fsgen_test_" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            var videoPath = Path.Combine(tempDir, "test.mp4");
+            File.WriteAllText(videoPath, "dummy");
+
+            using var vm = new PulseSidebarViewModel(_engine, _settingsService, _eventBus, _toastService);
+            InvokePrivate(vm, "OnEngineStateChanged", PulseState.Ready);
+            _eventBus.Publish(new VideoLoadedEvent { FilePath = videoPath });
+            var beatMap = CreateBeatMap(120);
+            SetPrivateField(_engine, "_currentBeatMap", beatMap);
+            InvokePrivate(vm, "OnBeatMapReady", beatMap);
+
+            vm.SelectedFunscriptBeatRateIndex = 1; // divisor 2
+
+            await InvokePrivateAsync(vm, "GenerateFunscriptAsync");
+
+            var fsPath = Path.ChangeExtension(videoPath, ".funscript");
+            Assert.True(File.Exists(fsPath));
+
+            var json = File.ReadAllText(fsPath);
+            // Count actions in the JSON — the filtered count should be half (rounded up) of the original
+            int totalBeats = beatMap.Beats.Count;
+            int expectedFiltered = (totalBeats + 1) / 2; // ceiling division for step-by-2
+            int actionCount = System.Text.Json.JsonDocument.Parse(json)
+                .RootElement.GetProperty("actions").GetArrayLength();
+            Assert.Equal(expectedFiltered, actionCount);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, true); } catch { }
+        }
+    }
+
+    // ══════════════════════════════════════════════
     //  Dispose — subscription cleanup
     // ══════════════════════════════════════════════
 


### PR DESCRIPTION
* Introduced a ComboBox for selecting beat rates in the Pulse sidebar.
* Added `PulseFunscriptBeatRateIndex` to persist selected beat rate.
* Implemented `FilterBeatsByDivisor` method to filter beats based on selection.
* Updated `GenerateFunscriptAsync` to utilize the selected beat rate.
* Enhanced tests for funscript generation and beat rate selection.