### PR TITLE
feat(viewmodel): throttle RepaintRequested to 30 Hz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Vido project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **VI-0028**: Throttled waveform `RepaintRequested` from ~60 Hz to ~30 Hz by skipping every other `UpdateTime()` call. `CurrentTimeSeconds` and `CurrentAmplitude` still update at full 60 Hz rate. Halves `OnPaintSurface` invocations without visible quality loss.
 - **VI-0027**: Integrated `WaveformStripRenderer` into `WaveformPanelView` for GPU-accelerated bitmap-blit waveform scrolling. `OnPaintSurface` now attempts strip-based rendering first (pre-rendered bitmap + cursor overlay), falling back to the existing per-frame SKPath rendering when the strip is not yet available. Strip renderer data is updated on `FullWaveform`, `AllBeats`, and `WindowDurationSeconds` property changes. Strip renderer is disposed on Unloaded and re-created on Loaded.
 - **VI-0026**: Added `WaveformStripRenderer` in `Vido.Services.Pulse` — a double-buffered off-screen waveform renderer that pre-renders a 3× canvas-width strip on a background thread and swaps it atomically for GPU-accelerated scrolling. Supports proactive re-render when the viewport approaches the strip edge, cancellation-safe rendering with periodic `CancellationToken` checks, and renders grid lines, waveform fill/outline, beat markers, and time labels.
 - **VI-0019**: Added "(modified)" visual indicator in the profile toolbar that appears in italic amber (#CC9900) text when current axis settings diverge from the selected profile. Uses existing `IsProfileModified` property and `BoolToVisibility` converter.

--- a/src/Vido.ViewModels/Pulse/WaveformViewModel.cs
+++ b/src/Vido.ViewModels/Pulse/WaveformViewModel.cs
@@ -24,6 +24,7 @@ internal sealed class WaveformViewModel : INotifyPropertyChanged, IDisposable
     private double _currentAmplitude;
     private bool _isActive;
     private bool _disposed;
+    private bool _repaintSkip;
 
     /// <summary>Raised when a property value changes.</summary>
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -163,12 +164,19 @@ internal sealed class WaveformViewModel : INotifyPropertyChanged, IDisposable
 
     /// <summary>
     /// Update current playback position. Called at ~60 Hz during playback.
+    /// Fires <see cref="RepaintRequested"/> at ~30 Hz (every other call) to
+    /// halve rendering cost without visible quality loss.
     /// </summary>
     public void UpdateTime(double seconds)
     {
         if (_disposed) return;
         CurrentTimeSeconds = seconds;
         CurrentAmplitude = _engine.CurrentAmplitude;
+
+        // Throttle to ~30 Hz: skip every other repaint request.
+        _repaintSkip = !_repaintSkip;
+        if (_repaintSkip) return;
+
         RepaintRequested?.Invoke();
     }
 

--- a/tests/Vido.Tests/PulseViewModelTests.cs
+++ b/tests/Vido.Tests/PulseViewModelTests.cs
@@ -696,7 +696,9 @@ public class PulseViewModelTests : IDisposable
         bool repaintFired = false;
         vm.RepaintRequested += () => repaintFired = true;
 
+        // First call skips (throttle), second call fires
         vm.UpdateTime(10.0);
+        vm.UpdateTime(10.5);
 
         Assert.True(repaintFired);
     }
@@ -706,13 +708,15 @@ public class PulseViewModelTests : IDisposable
     {
         using var vm = new WaveformViewModel(_engine, _settingsService);
         vm.UpdateTime(10.0);
+        vm.UpdateTime(10.5); // fire so next skip aligns
 
         bool repaintFired = false;
         vm.RepaintRequested += () => repaintFired = true;
 
-        vm.UpdateTime(10.0); // time unchanged (within threshold)
+        vm.UpdateTime(10.0); // skip (throttle)
+        vm.UpdateTime(10.0); // fire — time unchanged but repaint still fires
 
-        Assert.True(repaintFired); // repaint always fires
+        Assert.True(repaintFired);
     }
 
     [Fact]
@@ -724,8 +728,34 @@ public class PulseViewModelTests : IDisposable
         vm.Dispose();
 
         vm.UpdateTime(10.0);
+        vm.UpdateTime(10.5);
 
         Assert.False(repaintFired);
+    }
+
+    [Fact]
+    public void WaveformVM_UpdateTime_ThrottlesToHalfRate()
+    {
+        using var vm = new WaveformViewModel(_engine, _settingsService);
+        int repaintCount = 0;
+        vm.RepaintRequested += () => repaintCount++;
+
+        for (int i = 0; i < 10; i++)
+            vm.UpdateTime(i * 0.5);
+
+        Assert.Equal(5, repaintCount);
+    }
+
+    [Fact]
+    public void WaveformVM_UpdateTime_CurrentTimeUpdatedOnEveryCall()
+    {
+        using var vm = new WaveformViewModel(_engine, _settingsService);
+
+        for (int i = 1; i <= 6; i++)
+        {
+            vm.UpdateTime(i * 1.0);
+            Assert.Equal(i * 1.0, vm.CurrentTimeSeconds, 0.01);
+        }
     }
 
     // ══════════════════════════════════════════════


### PR DESCRIPTION
* Skip every other UpdateTime() call to reduce rendering cost.
* CurrentTimeSeconds and CurrentAmplitude still update at 60 Hz.
* Halves OnPaintSurface invocations without visible quality loss.