### PR TITLE
feat(pulse): add stroke controls and settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **vido-194**: Added `StrokePattern` enum (Classic, DoubleTap, TripleTap, HoldTop, HoldBottom) and `PulseStrokeSettings` sealed record (AmplitudeOffset, EasingBlend, Pattern, Randomness) in `Vido.Core.Models.Pulse`. Extended `AppSettings` with four new stroke control properties (`PulseAmplitudeOffset`, `PulseEasingBlend`, `PulseStrokePattern`, `PulseRandomness`) including `ResetToDefaults()` support. Includes 20 unit tests.
+
 ### Changed
 - **vido-183**: Added dark-neutral default button background (`ButtonDefaultBackgroundColor` #313131, `ButtonDefaultBackgroundBrush`) to both installer and main app theme resources. All primary action buttons in the installer (Welcome, Options, Finish pages) and UpdateDialog (Update Now, Restart Now, Open Release Page, OK) now display a dark gray (#313131) background by default and transition to accent blue (#0078d4) on hover. Secondary buttons (Later, Cancel, Close) remain unchanged. No functional changes — visual styling only.
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## [0.23.0]
+
+### What's New
+- Pulse stroke controls: fine-tune haptic motion with amplitude, speed, pattern, and randomness sliders
+- Amplitude slider adjusts stroke intensity from no movement to full-range strokes
+- Speed slider controls stroke feel from gentle and smooth to aggressive and snappy
+- Five stroke patterns: Classic, Double Tap, Triple Tap, Hold Top, and Hold Bottom
+- Randomness slider adds organic variation to stroke amplitude for a more natural feel
+- All stroke controls are baked into generated funscripts
+- Reorganized Pulse sidebar with dedicated "Stroke Controls" section
+
 ## [0.22.0]
 
 ### What's New

--- a/src/Vido.Core/Models/Pulse/PulseStrokeSettings.cs
+++ b/src/Vido.Core/Models/Pulse/PulseStrokeSettings.cs
@@ -1,0 +1,32 @@
+namespace Vido.Core.Models.Pulse;
+
+/// <summary>
+/// Immutable settings controlling Pulse stroke behavior — amplitude, easing, pattern, and randomness.
+/// </summary>
+public sealed record PulseStrokeSettings
+{
+    /// <summary>
+    /// Additive amplitude offset. −1.0 = zero movement, 0.0 = default (audio-driven),
+    /// +1.0 = full-range strokes.
+    /// </summary>
+    public double AmplitudeOffset { get; init; }
+
+    /// <summary>
+    /// Easing blend. −1.0 = gentle (sinusoidal), 0.0 = default (quadratic),
+    /// +1.0 = aggressive (linear).
+    /// </summary>
+    public double EasingBlend { get; init; }
+
+    /// <summary>
+    /// Stroke waveform pattern. Default: Classic.
+    /// </summary>
+    public StrokePattern Pattern { get; init; }
+
+    /// <summary>
+    /// Random amplitude variation per beat. 0.0 = none, 1.0 = full (0.2×–1.0× random multiplier).
+    /// </summary>
+    public double Randomness { get; init; }
+
+    /// <summary>Default settings matching current behavior.</summary>
+    public static PulseStrokeSettings Default { get; } = new();
+}

--- a/src/Vido.Core/Models/Pulse/StrokePattern.cs
+++ b/src/Vido.Core/Models/Pulse/StrokePattern.cs
@@ -1,0 +1,22 @@
+namespace Vido.Core.Models.Pulse;
+
+/// <summary>
+/// Defines the available stroke waveform patterns for Pulse haptic motion.
+/// </summary>
+public enum StrokePattern
+{
+    /// <summary>Standard up/down stroke per beat.</summary>
+    Classic,
+
+    /// <summary>Two up/down cycles per beat interval.</summary>
+    DoubleTap,
+
+    /// <summary>Three up/down cycles per beat interval.</summary>
+    TripleTap,
+
+    /// <summary>Stroke up, hold at top, then return.</summary>
+    HoldTop,
+
+    /// <summary>Stroke down, hold at bottom, then return.</summary>
+    HoldBottom
+}

--- a/src/Vido.Core/Settings/AppSettings.cs
+++ b/src/Vido.Core/Settings/AppSettings.cs
@@ -208,6 +208,28 @@ public sealed class AppSettings
     /// </summary>
     public int PulseFunscriptBeatRateIndex { get; set; } = 0;
 
+    // --- Pulse Stroke Controls ---
+
+    /// <summary>
+    /// Additive amplitude offset for Pulse strokes. −1.0 = zero movement, 0.0 = default, +1.0 = full-range.
+    /// </summary>
+    public double PulseAmplitudeOffset { get; set; } = 0.0;
+
+    /// <summary>
+    /// Easing blend for Pulse strokes. −1.0 = gentle (sinusoidal), 0.0 = default (quadratic), +1.0 = aggressive (linear).
+    /// </summary>
+    public double PulseEasingBlend { get; set; } = 0.0;
+
+    /// <summary>
+    /// Stroke waveform pattern name for Pulse. Stored as string for forward compatibility.
+    /// </summary>
+    public string PulseStrokePattern { get; set; } = "Classic";
+
+    /// <summary>
+    /// Random amplitude variation per beat for Pulse. 0.0 = none, 1.0 = full.
+    /// </summary>
+    public double PulseRandomness { get; set; } = 0.0;
+
     // --- General ---
 
     /// <summary>
@@ -301,6 +323,10 @@ public sealed class AppSettings
         PulseUsePulse = false;
         PulseBeatRateIndex = 0;
         PulseFunscriptBeatRateIndex = 0;
+        PulseAmplitudeOffset = 0.0;
+        PulseEasingBlend = 0.0;
+        PulseStrokePattern = "Classic";
+        PulseRandomness = 0.0;
 
         // General settings
         ToastDurationSeconds = 3.0;

--- a/tests/Vido.Tests/PulseStrokeControlModelTests.cs
+++ b/tests/Vido.Tests/PulseStrokeControlModelTests.cs
@@ -1,0 +1,240 @@
+using Vido.Core.Models.Pulse;
+using Vido.Core.Settings;
+using Xunit;
+
+namespace Vido.Tests;
+
+/// <summary>
+/// Unit tests for vido-194: StrokePattern enum, PulseStrokeSettings record,
+/// and AppSettings stroke control extensions.
+/// </summary>
+public sealed class PulseStrokeControlModelTests
+{
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ StrokePattern Enum Tests                                       ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    /// <summary>
+    /// Verifies that StrokePattern has exactly 5 values.
+    /// </summary>
+    [Fact]
+    public void StrokePattern_HasFiveValues()
+    {
+        var values = Enum.GetValues<StrokePattern>();
+
+        Assert.Equal(5, values.Length);
+    }
+
+    /// <summary>
+    /// Verifies all expected StrokePattern values exist and have correct ordinal values.
+    /// </summary>
+    [Theory]
+    [InlineData(StrokePattern.Classic, 0)]
+    [InlineData(StrokePattern.DoubleTap, 1)]
+    [InlineData(StrokePattern.TripleTap, 2)]
+    [InlineData(StrokePattern.HoldTop, 3)]
+    [InlineData(StrokePattern.HoldBottom, 4)]
+    public void StrokePattern_HasExpectedOrdinalValue(StrokePattern pattern, int expectedOrdinal)
+    {
+        Assert.Equal(expectedOrdinal, (int)pattern);
+    }
+
+    /// <summary>
+    /// Verifies that default StrokePattern is Classic.
+    /// </summary>
+    [Fact]
+    public void StrokePattern_Default_IsClassic()
+    {
+        StrokePattern pattern = default;
+
+        Assert.Equal(StrokePattern.Classic, pattern);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ PulseStrokeSettings Tests                                      ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    /// <summary>
+    /// Verifies that PulseStrokeSettings.Default has all zero/Classic values.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_Default_HasExpectedValues()
+    {
+        var settings = PulseStrokeSettings.Default;
+
+        Assert.Equal(0.0, settings.AmplitudeOffset);
+        Assert.Equal(0.0, settings.EasingBlend);
+        Assert.Equal(StrokePattern.Classic, settings.Pattern);
+        Assert.Equal(0.0, settings.Randomness);
+    }
+
+    /// <summary>
+    /// Verifies that a new PulseStrokeSettings instance matches Default values.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_NewInstance_MatchesDefault()
+    {
+        var fresh = new PulseStrokeSettings();
+        var def = PulseStrokeSettings.Default;
+
+        Assert.Equal(def.AmplitudeOffset, fresh.AmplitudeOffset);
+        Assert.Equal(def.EasingBlend, fresh.EasingBlend);
+        Assert.Equal(def.Pattern, fresh.Pattern);
+        Assert.Equal(def.Randomness, fresh.Randomness);
+    }
+
+    /// <summary>
+    /// Verifies that PulseStrokeSettings.Default is a singleton instance.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_Default_IsSingleton()
+    {
+        Assert.Same(PulseStrokeSettings.Default, PulseStrokeSettings.Default);
+    }
+
+    /// <summary>
+    /// Verifies that PulseStrokeSettings init properties can be set.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_InitProperties_CanBeSet()
+    {
+        var settings = new PulseStrokeSettings
+        {
+            AmplitudeOffset = 0.5,
+            EasingBlend = -0.3,
+            Pattern = StrokePattern.DoubleTap,
+            Randomness = 0.75,
+        };
+
+        Assert.Equal(0.5, settings.AmplitudeOffset);
+        Assert.Equal(-0.3, settings.EasingBlend);
+        Assert.Equal(StrokePattern.DoubleTap, settings.Pattern);
+        Assert.Equal(0.75, settings.Randomness);
+    }
+
+    /// <summary>
+    /// Verifies record equality semantics — two instances with same values are equal.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_RecordEquality_SameValues_AreEqual()
+    {
+        var a = new PulseStrokeSettings { AmplitudeOffset = 0.5, EasingBlend = -1.0, Pattern = StrokePattern.HoldTop, Randomness = 0.2 };
+        var b = new PulseStrokeSettings { AmplitudeOffset = 0.5, EasingBlend = -1.0, Pattern = StrokePattern.HoldTop, Randomness = 0.2 };
+
+        Assert.Equal(a, b);
+    }
+
+    /// <summary>
+    /// Verifies record equality semantics — two instances with different values are not equal.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_RecordEquality_DifferentValues_AreNotEqual()
+    {
+        var a = new PulseStrokeSettings { AmplitudeOffset = 0.5 };
+        var b = new PulseStrokeSettings { AmplitudeOffset = -0.5 };
+
+        Assert.NotEqual(a, b);
+    }
+
+    /// <summary>
+    /// Verifies that PulseStrokeSettings with expression creates a modified copy.
+    /// </summary>
+    [Fact]
+    public void PulseStrokeSettings_WithExpression_CreatesModifiedCopy()
+    {
+        var original = new PulseStrokeSettings { AmplitudeOffset = 0.5, Randomness = 0.3 };
+        var modified = original with { Pattern = StrokePattern.TripleTap };
+
+        Assert.Equal(0.5, modified.AmplitudeOffset);
+        Assert.Equal(0.3, modified.Randomness);
+        Assert.Equal(StrokePattern.TripleTap, modified.Pattern);
+        Assert.Equal(StrokePattern.Classic, original.Pattern);
+    }
+
+    // ╔══════════════════════════════════════════════════════════════════╗
+    // ║ AppSettings Stroke Control Extensions Tests                    ║
+    // ╚══════════════════════════════════════════════════════════════════╝
+
+    /// <summary>
+    /// Verifies that new AppSettings has correct stroke control defaults.
+    /// </summary>
+    [Fact]
+    public void AppSettings_NewInstance_HasStrokeControlDefaults()
+    {
+        var settings = new AppSettings();
+
+        Assert.Equal(0.0, settings.PulseAmplitudeOffset);
+        Assert.Equal(0.0, settings.PulseEasingBlend);
+        Assert.Equal("Classic", settings.PulseStrokePattern);
+        Assert.Equal(0.0, settings.PulseRandomness);
+    }
+
+    /// <summary>
+    /// Verifies that ResetToDefaults restores all stroke control properties.
+    /// </summary>
+    [Fact]
+    public void AppSettings_ResetToDefaults_RestoresStrokeControlProperties()
+    {
+        var settings = new AppSettings
+        {
+            PulseAmplitudeOffset = 0.75,
+            PulseEasingBlend = -0.5,
+            PulseStrokePattern = "DoubleTap",
+            PulseRandomness = 0.9,
+        };
+
+        settings.ResetToDefaults();
+
+        Assert.Equal(0.0, settings.PulseAmplitudeOffset);
+        Assert.Equal(0.0, settings.PulseEasingBlend);
+        Assert.Equal("Classic", settings.PulseStrokePattern);
+        Assert.Equal(0.0, settings.PulseRandomness);
+    }
+
+    /// <summary>
+    /// Verifies that reset stroke control properties match a fresh instance.
+    /// </summary>
+    [Fact]
+    public void AppSettings_ResetToDefaults_StrokeControls_MatchFreshInstance()
+    {
+        var mutated = new AppSettings
+        {
+            PulseAmplitudeOffset = 1.0,
+            PulseEasingBlend = 1.0,
+            PulseStrokePattern = "HoldBottom",
+            PulseRandomness = 1.0,
+        };
+
+        mutated.ResetToDefaults();
+        var fresh = new AppSettings();
+
+        Assert.Equal(fresh.PulseAmplitudeOffset, mutated.PulseAmplitudeOffset);
+        Assert.Equal(fresh.PulseEasingBlend, mutated.PulseEasingBlend);
+        Assert.Equal(fresh.PulseStrokePattern, mutated.PulseStrokePattern);
+        Assert.Equal(fresh.PulseRandomness, mutated.PulseRandomness);
+    }
+
+    /// <summary>
+    /// Verifies that stroke control properties can be set to boundary values.
+    /// </summary>
+    [Theory]
+    [InlineData(-1.0, -1.0, "Classic", 0.0)]
+    [InlineData(1.0, 1.0, "HoldBottom", 1.0)]
+    [InlineData(0.0, 0.0, "TripleTap", 0.5)]
+    public void AppSettings_StrokeControls_AcceptBoundaryValues(
+        double amplitude, double easing, string pattern, double randomness)
+    {
+        var settings = new AppSettings
+        {
+            PulseAmplitudeOffset = amplitude,
+            PulseEasingBlend = easing,
+            PulseStrokePattern = pattern,
+            PulseRandomness = randomness,
+        };
+
+        Assert.Equal(amplitude, settings.PulseAmplitudeOffset);
+        Assert.Equal(easing, settings.PulseEasingBlend);
+        Assert.Equal(pattern, settings.PulseStrokePattern);
+        Assert.Equal(randomness, settings.PulseRandomness);
+    }
+}


### PR DESCRIPTION
* Introduced `StrokePattern` enum with five patterns: Classic, DoubleTap, TripleTap, HoldTop, HoldBottom.
* Added `PulseStrokeSettings` record for controlling stroke behavior with properties for amplitude, easing, pattern, and randomness.
* Extended `AppSettings` with new properties for pulse stroke controls: `PulseAmplitudeOffset`, `PulseEasingBlend`, `PulseStrokePattern`, `PulseRandomness`.
* Implemented `ResetToDefaults()` support for new settings.
* Added 20 unit tests to validate new functionality.