### PR TITLE
feat(vido-212): remove Pulse panel and related settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+- **vido-212**: Removed Pulse panel from sidebar, activity bar, and settings UI. Deleted `Pulse` member from `SidebarPanelKind` enum, removed Pulse button from `ActivityBarView`, removed `BuildPulseSettings()` from `SettingsViewModel`, and removed Pulse case from `MainWindow.OnPanelChanged`. Updated all related tests.
+
 ### Added
 - **vido-200**: Added comprehensive ViewModel stroke control integration tests in `PulseSidebarViewModelStrokeControlTests.cs` (48 tests). Covers initialization from AppSettings (all controls, defaults, invalid/empty pattern fallback), persistence to AppSettings with QueueSave verification, engine propagation (constructor and per-property), value clamping (AmplitudeOffset ±1, EasingBlend ±1, Randomness 0–1, PatternIndex 0–4), PropertyChanged notifications and same-value guards, display label formatting, StrokePatternOptions mapping, and end-to-end funscript generation with DoubleTap/HoldTop/min-max amplitude/beat rate+TripleTap combinations. Combined with existing per-ticket tests: PulseTCodeMapper 93.68% (65 tests), FunscriptWriter 99.32% (71 tests), PulseSidebarViewModel 98.69% (166 tests). Total: 2159 tests, all passing.
 - **vido-199**: Added "STROKE CONTROLS" UI section to `PulseSidebarView.xaml` with custom `PulseSliderStyle` in `PulseStyles.xaml`. Section contains Beat Rate ComboBox (relocated from Generate Funscript area), Amplitude slider (−1 to +1 with value label), Speed slider (−1 to +1 with "Gentle"/"Aggressive" endpoint labels), Pattern ComboBox (bound to `StrokePatternOptions`/`SelectedStrokePatternIndex`), and Randomness slider (0 to 1 with percentage label). All controls are two-way bound to `PulseSidebarViewModel` properties and gated on `ShowBpm` visibility. `PulseSliderStyle` features a 3px track, 14px accent-colored thumb (grows to 16px on hover), and optional tick marks.

--- a/src/Vido.Core/Layout/SidebarPanelKind.cs
+++ b/src/Vido.Core/Layout/SidebarPanelKind.cs
@@ -21,11 +21,6 @@ public enum SidebarPanelKind
     Osr2Plus,
 
     /// <summary>
-    /// Pulse audio-driven haptic engine panel.
-    /// </summary>
-    Pulse,
-
-    /// <summary>
     /// Application settings.
     /// </summary>
     Settings

--- a/src/Vido.ViewModels/SettingsViewModel.cs
+++ b/src/Vido.ViewModels/SettingsViewModel.cs
@@ -77,7 +77,7 @@ public partial class SettingsViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Creates all settings categories: Playback, File Explorer, Screenshot, OSR2+, Pulse, Playlists.
+    /// Creates all settings categories: Playback, File Explorer, Screenshot, OSR2+, Playlists.
     /// Each setting is defined as a <see cref="SettingDefinition"/> with compile-time-safe
     /// getter/setter delegates for direct <see cref="AppSettings"/> property access.
     /// </summary>
@@ -227,9 +227,6 @@ public partial class SettingsViewModel : ObservableObject
         // ── OSR2+ ──
         BuildOsr2PlusSettings();
 
-        // ── Pulse ──
-        BuildPulseSettings();
-
         // ── Playlists ──
         BuildPlaylistSettings();
 
@@ -315,53 +312,6 @@ public partial class SettingsViewModel : ObservableObject
             .Select(d => new SettingDisplayItem(d, _settingsService, _settingsStore))
             .ToList();
         AllCategories.Add(new SettingsCategoryViewModel("OSR2+", items));
-    }
-
-    /// <summary>
-    /// Builds the Pulse settings category with beat detection and waveform settings.
-    /// </summary>
-    private void BuildPulseSettings()
-    {
-        var definitions = new List<SettingDefinition>
-        {
-            new(
-                Key: "pulse.beatSensitivity",
-                Type: "number",
-                DefaultValue: 1.5,
-                Title: "Beat Detection Sensitivity",
-                Description: "Sensitivity multiplier for audio beat detection (0.5–5.0). Higher = more sensitive.",
-                Section: "Beat Detection",
-                Getter: s => s.PulseBeatSensitivity,
-                Setter: (s, v) => s.PulseBeatSensitivity = Convert.ToDouble(v ?? 1.5)),
-            new(
-                Key: "pulse.enableBpmPhaseLock",
-                Type: "boolean",
-                DefaultValue: true,
-                Title: "Enable BPM Phase Lock",
-                Description: "Lock beat detection to a consistent BPM phase for more stable beat timing.",
-                Section: "Beat Detection",
-                Getter: s => s.PulseEnableBpmPhaseLock,
-                Setter: (s, v) => s.PulseEnableBpmPhaseLock = v is true),
-            new(
-                Key: "pulse.waveformWindowDuration",
-                Type: "enum",
-                DefaultValue: "30",
-                Title: "Waveform Window Duration",
-                Description: "Duration of the waveform visualization window in seconds.",
-                Section: "Visualizer",
-                EnumValues: ["15", "30", "60", "120"],
-                Getter: s => s.PulseWaveformWindowDuration.ToString(),
-                Setter: (s, v) =>
-                {
-                    if (int.TryParse(v?.ToString(), out var dur))
-                        s.PulseWaveformWindowDuration = dur;
-                }),
-        };
-
-        var items = definitions
-            .Select(d => new SettingDisplayItem(d, _settingsService, _settingsStore))
-            .ToList();
-        AllCategories.Add(new SettingsCategoryViewModel("Pulse", items));
     }
 
     /// <summary>

--- a/src/Vido.ViewModels/SidebarViewModel.cs
+++ b/src/Vido.ViewModels/SidebarViewModel.cs
@@ -23,7 +23,6 @@ public partial class SidebarViewModel : ObservableObject
             SidebarPanelKind.Explorer => "EXPLORER",
             SidebarPanelKind.Playlists => "PLAYLISTS",
             SidebarPanelKind.Osr2Plus => "OSR2+",
-            SidebarPanelKind.Pulse => "PULSE",
             SidebarPanelKind.Settings => "SETTINGS",
             _ => "EXPLORER"
         };

--- a/src/Vido.Views/Controls/ActivityBarView.xaml
+++ b/src/Vido.Views/Controls/ActivityBarView.xaml
@@ -57,18 +57,6 @@
                        Opacity="0.6" />
             </Button>
 
-            <!-- Pulse sidebar button — uses embedded Pulse icon -->
-            <Button x:Name="PulseButton"
-                    Style="{StaticResource ActivityBarButtonStyle}"
-                    ToolTip="Pulse"
-                    Click="OnPulseClick">
-                <Image Source="pack://application:,,,/Vido.Views;component/Assets/Pulse/sidebar-icon.png"
-                       Width="24" Height="24"
-                       Stretch="Uniform"
-                       SnapsToDevicePixels="True"
-                       Opacity="0.6" />
-            </Button>
-
             <!-- Playlists sidebar button — uses embedded Playlists icon -->
             <Button x:Name="PlaylistsButton"
                     Style="{StaticResource ActivityBarButtonStyle}"

--- a/src/Vido.Views/Controls/ActivityBarView.xaml.cs
+++ b/src/Vido.Views/Controls/ActivityBarView.xaml.cs
@@ -33,7 +33,6 @@ public partial class ActivityBarView : UserControl
 
         SetButtonActive(ExplorerButton, vm.IsPanelActive(SidebarPanelKind.Explorer) && vm.IsSidebarVisible);
         SetButtonActive(Osr2PlusButton, vm.IsPanelActive(SidebarPanelKind.Osr2Plus) && vm.IsSidebarVisible);
-        SetButtonActive(PulseButton, vm.IsPanelActive(SidebarPanelKind.Pulse) && vm.IsSidebarVisible);
         SetButtonActive(PlaylistsButton, vm.IsPanelActive(SidebarPanelKind.Playlists) && vm.IsSidebarVisible);
         SetButtonActive(SettingsButton, vm.IsPanelActive(SidebarPanelKind.Settings) && vm.IsSidebarVisible);
     }
@@ -53,16 +52,6 @@ public partial class ActivityBarView : UserControl
         if (DataContext is ActivityBarViewModel vm)
         {
             vm.SelectPanelCommand.Execute(SidebarPanelKind.Osr2Plus);
-            UpdateActiveStates();
-            RaisePanelChanged();
-        }
-    }
-
-    private void OnPulseClick(object sender, RoutedEventArgs e)
-    {
-        if (DataContext is ActivityBarViewModel vm)
-        {
-            vm.SelectPanelCommand.Execute(SidebarPanelKind.Pulse);
             UpdateActiveStates();
             RaisePanelChanged();
         }

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1505,9 +1505,6 @@ public partial class MainWindow : Window
                 case SidebarPanelKind.Osr2Plus:
                     Sidebar.SetPanelContent(_osr2SidebarContent);
                     break;
-                case SidebarPanelKind.Pulse:
-                    Sidebar.SetPanelContent(_pulseSidebarContent);
-                    break;
                 case SidebarPanelKind.Playlists:
                     Sidebar.SetPanelContent(_playlistSidebarContent);
                     break;

--- a/tests/Vido.Tests/ActivityBarViewModelTests.cs
+++ b/tests/Vido.Tests/ActivityBarViewModelTests.cs
@@ -152,7 +152,6 @@ public class ActivityBarViewModelTests
     [InlineData(SidebarPanelKind.Explorer)]
     [InlineData(SidebarPanelKind.Playlists)]
     [InlineData(SidebarPanelKind.Osr2Plus)]
-    [InlineData(SidebarPanelKind.Pulse)]
     [InlineData(SidebarPanelKind.Settings)]
     public void SelectPanel_AllPanels_Work(SidebarPanelKind panel)
     {
@@ -219,7 +218,6 @@ public class ActivityBarViewModelTests
         Assert.False(vm.IsPanelActive(SidebarPanelKind.Explorer));
         Assert.False(vm.IsPanelActive(SidebarPanelKind.Playlists));
         Assert.False(vm.IsPanelActive(SidebarPanelKind.Osr2Plus));
-        Assert.False(vm.IsPanelActive(SidebarPanelKind.Pulse));
         Assert.False(vm.IsPanelActive(SidebarPanelKind.Settings));
     }
 

--- a/tests/Vido.Tests/FeatureSettingsTests.cs
+++ b/tests/Vido.Tests/FeatureSettingsTests.cs
@@ -300,7 +300,7 @@ public sealed class FeatureSettingsTests
     {
         var values = Enum.GetValues<SidebarPanelKind>();
 
-        Assert.Equal(5, values.Length);
+        Assert.Equal(4, values.Length);
     }
 
     /// <summary>
@@ -310,7 +310,6 @@ public sealed class FeatureSettingsTests
     [InlineData(SidebarPanelKind.Explorer)]
     [InlineData(SidebarPanelKind.Playlists)]
     [InlineData(SidebarPanelKind.Osr2Plus)]
-    [InlineData(SidebarPanelKind.Pulse)]
     [InlineData(SidebarPanelKind.Settings)]
     public void SidebarPanelKind_ContainsExpectedMembers(SidebarPanelKind kind)
     {

--- a/tests/Vido.Tests/SettingsViewModelTests.cs
+++ b/tests/Vido.Tests/SettingsViewModelTests.cs
@@ -36,13 +36,12 @@ public sealed class SettingsViewModelTests
     {
         var vm = CreateViewModel();
 
-        Assert.Equal(8, vm.AllCategories.Count);
+        Assert.Equal(7, vm.AllCategories.Count);
         Assert.Contains(vm.AllCategories, c => c.Name == "General");
         Assert.Contains(vm.AllCategories, c => c.Name == "Playback");
         Assert.Contains(vm.AllCategories, c => c.Name == "File Explorer");
         Assert.Contains(vm.AllCategories, c => c.Name == "Screenshot");
         Assert.Contains(vm.AllCategories, c => c.Name == "OSR2+");
-        Assert.Contains(vm.AllCategories, c => c.Name == "Pulse");
         Assert.Contains(vm.AllCategories, c => c.Name == "Playlists");
         Assert.Contains(vm.AllCategories, c => c.Name == "Updates");
     }
@@ -108,21 +107,6 @@ public sealed class SettingsViewModelTests
         Assert.Contains(category.Settings, s => s.Id == "osr2.outputRate");
         Assert.Contains(category.Settings, s => s.Id == "osr2.globalOffset");
         Assert.Contains(category.Settings, s => s.Id == "osr2.visualizerWindowDuration");
-    }
-
-    /// <summary>
-    /// Verifies that Pulse category has expected settings.
-    /// </summary>
-    [Fact]
-    public void Constructor_PulseCategory_HasExpectedSettings()
-    {
-        var vm = CreateViewModel();
-        var category = vm.AllCategories.First(c => c.Name == "Pulse");
-
-        Assert.Equal(3, category.Settings.Count);
-        Assert.Contains(category.Settings, s => s.Id == "pulse.beatSensitivity");
-        Assert.Contains(category.Settings, s => s.Id == "pulse.enableBpmPhaseLock");
-        Assert.Contains(category.Settings, s => s.Id == "pulse.waveformWindowDuration");
     }
 
     /// <summary>

--- a/tests/Vido.Tests/SidebarViewModelTests.cs
+++ b/tests/Vido.Tests/SidebarViewModelTests.cs
@@ -29,7 +29,6 @@ public class SidebarViewModelTests
     [InlineData(SidebarPanelKind.Explorer, "EXPLORER")]
     [InlineData(SidebarPanelKind.Playlists, "PLAYLISTS")]
     [InlineData(SidebarPanelKind.Osr2Plus, "OSR2+")]
-    [InlineData(SidebarPanelKind.Pulse, "PULSE")]
     [InlineData(SidebarPanelKind.Settings, "SETTINGS")]
     public void SetPanel_UpdatesHeaderText(SidebarPanelKind panel, string expected)
     {


### PR DESCRIPTION
* Removed Pulse panel from sidebar, activity bar, and settings UI.
* Deleted `Pulse` member from `SidebarPanelKind` enum.
* Removed Pulse button from `ActivityBarView`.
* Eliminated `BuildPulseSettings()` from `SettingsViewModel`.
* Updated related tests to reflect these changes.