### PR TITLE
refactor(TCodeService, InterpolationService): optimize axis handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **vido-234**: Optimized `TCodeService` and `InterpolationService` by replacing 8 `Dictionary<string, ...>` fields with fixed-size arrays indexed by `AxisConfig.Ordinal`. Added `Ordinal` property to `AxisConfig` (assigned in `SetAxisConfigs`). Changed `InterpolationService.GetPosition` signature from `string axisId` to `int axisOrdinal` and replaced `ConcurrentDictionary<string, int>` index cache with `int[]`. Added `InterpolationService.SetAxisCount()`. Converted `IsDirty` from `string`-based to `int ordinal`-based lookup. Added `GetOrdinalForId()` helper for non-hot-path string-to-ordinal resolution. Sentinel values: `-1` (unsent TCode), `double.NaN` (inactive ramp/return), `null` (absent objects). Added `InternalsVisibleTo("Vido.Services")` and `InternalsVisibleTo("Vido.Tests")` to `Vido.Core.csproj`. Updated all tests to call `SetAxisConfigs` before `SetScripts`/`StartTestAxis` and use integer ordinals for `IsDirty`/`GetPosition`.
+
 ### Removed
 - **vido-233**: Removed unused `SkiaSharp` NuGet package reference from `Vido.Core.csproj`. Zero SkiaSharp imports existed in Core — SkiaSharp is correctly consumed only in `Vido.Views` via `SkiaSharp.Views.WPF`. `SkiaSharpVersion` property retained in `Directory.Build.props`.
 - **vido-232**: Removed orphaned haptic event types (`HapticAxisConfigEvent`, `HapticScriptsChangedEvent`, `HapticTransportStateEvent`, `HapticAxisSnapshot`) and all publish call sites. Deleted 4 type files and the empty `Haptics` directory. Removed `PublishTransportState()` and `BuildConnectionLabel()` from `Osr2PlusSidebarViewModel`, `PublishOsr2AxisConfig()` from `MainWindow`, and dead code in the ScriptsChanged handler (preserved auto-show visualizer logic). Cleaned up `using Vido.Core.Haptics` from 6 files. Removed 10 tests (8 from `HapticTypesTests`, 2 transport-state tests from `Osr2ViewModelTests`).

--- a/src/Vido.Core/Models/Osr2Plus/AxisConfig.cs
+++ b/src/Vido.Core/Models/Osr2Plus/AxisConfig.cs
@@ -83,6 +83,14 @@ public class AxisConfig : INotifyPropertyChanged
     [JsonIgnore]
     public bool HasPositionOffset => Id is "L0" or "R0" or "R1" or "R2";
 
+    /// <summary>
+    /// Zero-based index into per-axis state arrays in <see cref="TCodeService"/> and <see cref="InterpolationService"/>.
+    /// Assigned dynamically by list index in <c>TCodeService.SetAxisConfigs</c>.
+    /// Not persisted — ephemeral runtime value.
+    /// </summary>
+    [JsonIgnore]
+    public int Ordinal { get; internal set; }
+
     /// <summary>Whether this is the primary stroke axis (L0).</summary>
     [JsonIgnore]
     public bool IsStroke => Id == "L0";

--- a/src/Vido.Core/Vido.Core.csproj
+++ b/src/Vido.Core/Vido.Core.csproj
@@ -8,4 +8,9 @@
     <Version>$(VidoVersion)</Version>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Vido.Services" />
+    <InternalsVisibleTo Include="Vido.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Vido.Services/Osr2Plus/InterpolationService.cs
+++ b/src/Vido.Services/Osr2Plus/InterpolationService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Vido.Core.Models.Osr2Plus;
 
 namespace Vido.Services.Osr2Plus;
@@ -11,9 +10,16 @@ namespace Vido.Services.Osr2Plus;
 public class InterpolationService
 {
     /// <summary>
-    /// Per-axis cached index for fast sequential lookups.
+    /// Per-axis cached index for fast sequential lookups. Indexed by axis ordinal.
     /// </summary>
-    private readonly ConcurrentDictionary<string, int> _cachedIndices = new();
+    private int[] _cachedIndices = Array.Empty<int>();
+
+    /// <summary>
+    /// Sets the number of axes, allocating the index cache array.
+    /// Called from <see cref="TCodeService.SetAxisConfigs"/>.
+    /// </summary>
+    /// <param name="count">Number of axis configurations.</param>
+    public void SetAxisCount(int count) => _cachedIndices = new int[count];
 
     /// <summary>
     /// Gets the interpolated position (0–100) at the given time in milliseconds.
@@ -21,9 +27,9 @@ public class InterpolationService
     /// </summary>
     /// <param name="script">The funscript data containing sorted actions.</param>
     /// <param name="timeMs">Current playback time in milliseconds.</param>
-    /// <param name="axisId">Axis identifier used for index caching.</param>
+    /// <param name="axisOrdinal">Axis ordinal index for index caching.</param>
     /// <returns>Interpolated position value between 0 and 100.</returns>
-    public double GetPosition(FunscriptData script, double timeMs, string axisId)
+    public double GetPosition(FunscriptData script, double timeMs, int axisOrdinal)
     {
         var actions = script.Actions;
 
@@ -42,9 +48,9 @@ public class InterpolationService
             return actions[^1].Pos;
 
         // Try to use cached index for fast sequential advancement
-        var lastIndex = _cachedIndices.GetOrAdd(axisId, 0);
+        var lastIndex = _cachedIndices[axisOrdinal];
         var lo = FindIndex(actions, timeMs, lastIndex);
-        _cachedIndices[axisId] = lo;
+        _cachedIndices[axisOrdinal] = lo;
 
         var hi = lo + 1;
         var a = actions[lo];
@@ -100,6 +106,6 @@ public class InterpolationService
     /// </summary>
     public void ResetIndices()
     {
-        _cachedIndices.Clear();
+        Array.Clear(_cachedIndices);
     }
 }

--- a/src/Vido.Services/Osr2Plus/TCodeService.cs
+++ b/src/Vido.Services/Osr2Plus/TCodeService.cs
@@ -36,14 +36,15 @@ public class TCodeService : IDisposable
     private bool _syncPlaying;            // whether media was playing at sync point
 
     // Axis data
-    private Dictionary<string, FunscriptData> _scripts = new();
+    private FunscriptData?[] _scriptsByAxis = Array.Empty<FunscriptData?>();
     private List<AxisConfig> _axisConfigs = new();
     private AxisConfig? _cachedStrokeConfig;
     private bool _hasActiveFillConfigs;
     private int _offsetMs;
+    private int _axisCount;
 
     // Dirty value tracking: only send axes whose TCode value changed
-    private readonly Dictionary<string, int> _lastSentValues = new();
+    private int[] _lastSentByAxis = Array.Empty<int>();
 
     // Reused output command buffer for allocation-free hot-path formatting.
     // 4 axes × (~12 bytes per command) + separators/newline fits comfortably.
@@ -56,27 +57,28 @@ public class TCodeService : IDisposable
     internal const double PitchFillMaxPosition = 100.0;
 
     // Random pattern generators — one per axis
-    private readonly Dictionary<string, RandomPatternGenerator> _randomGenerators = new();
+    private RandomPatternGenerator?[] _randomGenByAxis = Array.Empty<RandomPatternGenerator?>();
 
     // Stroke tracking for random synchronization
     private double _lastStrokePosition = 50.0;
     private double _cumulativeStrokeDistance;
 
     // Per-axis cumulative fill time (for independent pattern fill)
-    private readonly Dictionary<string, double> _cumulativeFillTime = new();
+    private double[] _cumulativeFillByAxis = Array.Empty<double>();
 
-    // Return-to-center: axis ID → current interpolated TCode position
-    private readonly Dictionary<string, double> _returningAxes = new();
+    // Return-to-center: axis ordinal → current interpolated TCode position (NaN = not returning)
+    private double[] _returningByAxis = Array.Empty<double>();
 
-    // Ramp-up: axis ID → blend factor (0.0 = midpoint, 1.0 = fully active)
-    private readonly Dictionary<string, double> _rampingAxes = new();
+    // Ramp-up: axis ordinal → blend factor (NaN = not ramping, 0.0 = midpoint, 1.0 = fully active)
+    private double[] _rampingByAxis = Array.Empty<double>();
 
     // Previous axis state snapshot for detecting transitions
-    private readonly Dictionary<string, (bool Enabled, AxisFillMode FillMode)> _prevAxisState = new();
+    private (bool Enabled, AxisFillMode FillMode, bool HasValue)[] _prevStateByAxis =
+        Array.Empty<(bool, AxisFillMode, bool)>();
 
     // ===== Test Mode State =====
     private readonly object _testLock = new();
-    private readonly Dictionary<string, TestAxisState> _testingAxes = new();
+    private TestAxisState?[] _testingByAxis = Array.Empty<TestAxisState?>();
     private readonly List<string> _stoppedTestIds = new(4);
 
     /// <summary>Raised when a test axis finishes ramping down.</summary>
@@ -89,10 +91,18 @@ public class TCodeService : IDisposable
     public int OutputRateHz => _outputRateHz;
 
     /// <summary>Gets a value indicating whether any axis has funscript data loaded.</summary>
-    public bool HasScriptsLoaded => _scripts.Count > 0;
+    public bool HasScriptsLoaded
+    {
+        get
+        {
+            for (int i = 0; i < _axisCount; i++)
+                if (_scriptsByAxis[i] != null) return true;
+            return false;
+        }
+    }
 
     /// <summary>Gets a value indicating whether funscript is actively playing (blocks test mode).</summary>
-    public bool IsFunscriptPlaying => _isPlaying && _scripts.Count > 0;
+    public bool IsFunscriptPlaying => _isPlaying && HasScriptsLoaded;
 
     /// <summary>
     /// Gets or sets the active transport (Serial or UDP). Set by the connection logic on connect.
@@ -122,36 +132,95 @@ public class TCodeService : IDisposable
     /// <param name="scripts">Dictionary of axisId → funscript data.</param>
     public void SetScripts(Dictionary<string, FunscriptData> scripts)
     {
-        _scripts = scripts;
-        _lastSentValues.Clear();
+        // Clear existing scripts
+        Array.Clear(_scriptsByAxis);
+
+        // Map incoming scripts to axis ordinals
+        foreach (var (axisId, data) in scripts)
+        {
+            var idx = GetOrdinalForId(axisId);
+            if (idx >= 0) _scriptsByAxis[idx] = data;
+        }
+
+        Array.Fill(_lastSentByAxis, -1);
         _interpolation.ResetIndices();
         // Reset stroke tracking and random generators on script change
         _cumulativeStrokeDistance = 0;
         _lastStrokePosition = 50.0;
-        _cumulativeFillTime.Clear();
-        foreach (var gen in _randomGenerators.Values) gen.Reset();
-
+        Array.Clear(_cumulativeFillByAxis);
+        for (int i = 0; i < _axisCount; i++)
+            _randomGenByAxis[i]?.Reset();
     }
 
     /// <summary>
     /// Sets the axis configurations (min/max/enabled/fill mode).
-    /// Detects transitions to trigger ramp-up and return-to-center animations.
+    /// Assigns ordinals, allocates per-axis state arrays, and detects
+    /// transitions to trigger ramp-up and return-to-center animations.
     /// </summary>
     /// <param name="configs">List of axis configurations.</param>
     public void SetAxisConfigs(List<AxisConfig> configs)
     {
+        var count = configs.Count;
+        for (int i = 0; i < count; i++)
+            configs[i].Ordinal = i;
+
+        // Snapshot old state before reallocating
+        var oldPrevState = _prevStateByAxis;
+        var oldAxisConfigs = _axisConfigs;
+        var oldLastSent = _lastSentByAxis;
+        var oldTestingByAxis = _testingByAxis;
+
+        // Allocate state arrays (only on config change, not hot path)
+        _scriptsByAxis = new FunscriptData?[count];
+        _lastSentByAxis = new int[count];
+        Array.Fill(_lastSentByAxis, -1);
+        _randomGenByAxis = new RandomPatternGenerator?[count];
+        _cumulativeFillByAxis = new double[count];
+        _returningByAxis = new double[count];
+        Array.Fill(_returningByAxis, double.NaN);
+        _rampingByAxis = new double[count];
+        Array.Fill(_rampingByAxis, double.NaN);
+        _prevStateByAxis = new (bool, AxisFillMode, bool)[count];
+        _testingByAxis = new TestAxisState?[count];
+        _axisCount = count;
+        _interpolation.SetAxisCount(count);
+
         AxisConfig? cachedStrokeConfig = null;
         bool hasActiveFillConfigs = false;
 
         foreach (var cfg in configs)
         {
+            var idx = cfg.Ordinal;
+
             if (cachedStrokeConfig == null && cfg.Id == "L0" && cfg.Enabled)
                 cachedStrokeConfig = cfg;
 
             if (!hasActiveFillConfigs && cfg.Enabled && cfg.FillMode != AxisFillMode.None)
                 hasActiveFillConfigs = true;
 
-            bool hasPrev = _prevAxisState.TryGetValue(cfg.Id, out var prev);
+            // Find previous state by matching axis ID in old configs
+            bool hasPrev = false;
+            (bool Enabled, AxisFillMode FillMode, bool HasValue) prev = default;
+            int oldIdx = -1;
+            for (int j = 0; j < oldAxisConfigs.Count; j++)
+            {
+                if (oldAxisConfigs[j].Id == cfg.Id)
+                {
+                    oldIdx = j;
+                    if (j < oldPrevState.Length && oldPrevState[j].HasValue)
+                    {
+                        prev = oldPrevState[j];
+                        hasPrev = true;
+                    }
+
+                    // Carry forward test state
+                    if (j < oldTestingByAxis.Length)
+                        _testingByAxis[idx] = oldTestingByAxis[j];
+
+                    break;
+                }
+            }
+
             if (hasPrev)
             {
                 bool wasEnabled = prev.Enabled;
@@ -164,23 +233,27 @@ public class TCodeService : IDisposable
                 bool fillJustCleared = wasActiveFill && nowEnabled && cfg.FillMode == AxisFillMode.None;
                 if (justDisabled || fillJustCleared)
                 {
-                    if (_lastSentValues.TryGetValue(cfg.Id, out var lastVal) && Math.Abs(lastVal - 500) >= 1)
+                    if (oldIdx >= 0 && oldIdx < oldLastSent.Length)
                     {
-                        _returningAxes[cfg.Id] = lastVal;
+                        var lastVal = oldLastSent[oldIdx];
+                        if (lastVal != -1 && Math.Abs(lastVal - 500) >= 1)
+                        {
+                            _returningByAxis[idx] = lastVal;
+                        }
                     }
-                    _rampingAxes.Remove(cfg.Id);
+                    _rampingByAxis[idx] = double.NaN;
                 }
 
                 // Ramp-up when: axis activated with active fill from inactive state
                 bool justActivated = nowActiveFill && (!wasActiveFill || !wasEnabled);
                 if (justActivated)
                 {
-                    _returningAxes.Remove(cfg.Id);
-                    _rampingAxes[cfg.Id] = 0.0;
+                    _returningByAxis[idx] = double.NaN;
+                    _rampingByAxis[idx] = 0.0;
                 }
             }
 
-            _prevAxisState[cfg.Id] = (cfg.Enabled, cfg.FillMode);
+            _prevStateByAxis[idx] = (cfg.Enabled, cfg.FillMode, true);
         }
 
         _axisConfigs = configs;
@@ -228,7 +301,7 @@ public class TCodeService : IDisposable
         _isPlaying = playing;
 
         // Auto-stop all test axes when funscript playback starts
-        if (playing && _scripts.Count > 0)
+        if (playing && HasScriptsLoaded)
         {
             StopAllTestAxes();
         }
@@ -294,8 +367,8 @@ public class TCodeService : IDisposable
             }
             _outputThread = null;
         }
-        _lastSentValues.Clear();
-        lock (_testLock) _testingAxes.Clear();
+        Array.Fill(_lastSentByAxis, -1);
+        lock (_testLock) Array.Clear(_testingByAxis);
     }
 
     // ===== Test Mode API =====
@@ -308,9 +381,11 @@ public class TCodeService : IDisposable
     public void StartTestAxis(string axisId, double speedHz)
     {
         speedHz = Math.Clamp(speedHz, 0.1, 5.0);
+        var idx = GetOrdinalForId(axisId);
+        if (idx < 0) return;
         lock (_testLock)
         {
-            _testingAxes[axisId] = new TestAxisState
+            _testingByAxis[idx] = new TestAxisState
             {
                 Phase = 0,
                 CurrentSpeedHz = speedHz,
@@ -322,8 +397,7 @@ public class TCodeService : IDisposable
         }
 
         // Reset cached random generator so it doesn't have stale _transitionStart
-        if (_randomGenerators.TryGetValue(axisId, out var gen))
-            gen.Reset();
+        _randomGenByAxis[idx]?.Reset();
     }
 
     /// <summary>
@@ -332,10 +406,15 @@ public class TCodeService : IDisposable
     /// <param name="axisId">The axis to stop testing.</param>
     public void StopTestAxis(string axisId)
     {
-        bool wasRemoved;
-        lock (_testLock)
+        var idx = GetOrdinalForId(axisId);
+        bool wasRemoved = false;
+        if (idx >= 0)
         {
-            wasRemoved = _testingAxes.Remove(axisId);
+            lock (_testLock)
+            {
+                wasRemoved = _testingByAxis[idx] != null;
+                _testingByAxis[idx] = null;
+            }
         }
 
         if (wasRemoved)
@@ -354,9 +433,12 @@ public class TCodeService : IDisposable
     public void UpdateTestSpeed(string axisId, double speedHz)
     {
         speedHz = Math.Clamp(speedHz, 0.1, 5.0);
+        var idx = GetOrdinalForId(axisId);
+        if (idx < 0) return;
         lock (_testLock)
         {
-            if (_testingAxes.TryGetValue(axisId, out var state))
+            var state = _testingByAxis[idx];
+            if (state != null)
             {
                 state.TargetSpeedHz = speedHz;
             }
@@ -370,7 +452,9 @@ public class TCodeService : IDisposable
     /// <returns><c>true</c> if the axis is currently being tested.</returns>
     public bool IsAxisTesting(string axisId)
     {
-        lock (_testLock) return _testingAxes.ContainsKey(axisId);
+        var idx = GetOrdinalForId(axisId);
+        if (idx < 0) return false;
+        lock (_testLock) return _testingByAxis[idx] != null;
     }
 
     /// <summary>
@@ -382,9 +466,14 @@ public class TCodeService : IDisposable
         _stoppedTestIds.Clear();
         lock (_testLock)
         {
-            foreach (var key in _testingAxes.Keys)
-                _stoppedTestIds.Add(key);
-            _testingAxes.Clear();
+            for (int i = 0; i < _axisCount; i++)
+            {
+                if (_testingByAxis[i] != null)
+                {
+                    _stoppedTestIds.Add(_axisConfigs[i].Id);
+                    _testingByAxis[i] = null;
+                }
+            }
         }
 
         // Send midpoints outside the lock
@@ -452,8 +541,12 @@ public class TCodeService : IDisposable
 
                 if (_transport?.IsConnected == true)
                 {
-                    bool hasTestAxes;
-                    lock (_testLock) hasTestAxes = _testingAxes.Count > 0;
+                    bool hasTestAxes = false;
+                    lock (_testLock)
+                    {
+                        for (int i = 0; i < _axisCount; i++)
+                            if (_testingByAxis[i] != null) { hasTestAxes = true; break; }
+                    }
 
                     bool hasFillOrReturn = HasActiveFillModes();
                     if (_isPlaying || hasFillOrReturn || hasTestAxes)
@@ -512,10 +605,14 @@ public class TCodeService : IDisposable
         double strokePosition = 50.0;
         bool hasStrokeScript = false;
         var strokeConfig = _cachedStrokeConfig;
-        if (strokeConfig != null && _scripts.TryGetValue("L0", out var strokeScript))
+        if (strokeConfig != null)
         {
-            strokePosition = _interpolation.GetPosition(strokeScript, currentTimeMs, "L0");
-            hasStrokeScript = true;
+            var strokeScript = _scriptsByAxis[strokeConfig.Ordinal];
+            if (strokeScript != null)
+            {
+                strokePosition = _interpolation.GetPosition(strokeScript, currentTimeMs, strokeConfig.Ordinal);
+                hasStrokeScript = true;
+            }
         }
         // Accumulate stroke travel distance for random/sync fill speed
         var strokeDelta = strokePosition - _lastStrokePosition;
@@ -536,7 +633,7 @@ public class TCodeService : IDisposable
             TestAxisState? testState = null;
             if (hasTestAxes)
             {
-                lock (_testLock) _testingAxes.TryGetValue(config.Id, out testState);
+                lock (_testLock) testState = _testingByAxis[config.Ordinal];
             }
 
             if (testState != null)
@@ -575,10 +672,12 @@ public class TCodeService : IDisposable
                 if (effectiveFillMode == AxisFillMode.Random)
                 {
                     // Random uses its own cosine-interpolated generator
-                    if (!_randomGenerators.TryGetValue(config.Id, out var generator))
+                    var idx = config.Ordinal;
+                    var generator = _randomGenByAxis[idx];
+                    if (generator == null)
                     {
                         generator = new RandomPatternGenerator(config.Min, config.Max);
-                        _randomGenerators[config.Id] = generator;
+                        _randomGenByAxis[idx] = generator;
                     }
                     generator.SetRange(config.Min, config.Max);
 
@@ -603,24 +702,25 @@ public class TCodeService : IDisposable
 
                 // Scale through axis min/max and apply offset
                 var testTcode = ApplyPositionOffset(config, PositionToTCode(config, testPosition));
-                if (IsDirty(config.Id, testTcode))
+                if (IsDirty(config.Ordinal, testTcode))
                 {
                     AppendCommand(config, testTcode, intervalMs);
-                    _lastSentValues[config.Id] = testTcode;
+                    _lastSentByAxis[config.Ordinal] = testTcode;
                 }
                 continue; // Skip normal playback for this axis
             }
 
             // Scripted axis: interpolate position from funscript
-            if (_isPlaying && _scripts.TryGetValue(config.Id, out var script))
+            var axisScript = _scriptsByAxis[config.Ordinal];
+            if (_isPlaying && axisScript != null)
             {
-                var position = _interpolation.GetPosition(script, currentTimeMs, config.Id);
+                var position = _interpolation.GetPosition(axisScript, currentTimeMs, config.Ordinal);
                 var tcodeValue = ApplyPositionOffset(config, PositionToTCode(config, position));
 
-                if (IsDirty(config.Id, tcodeValue))
+                if (IsDirty(config.Ordinal, tcodeValue))
                 {
                     AppendCommand(config, tcodeValue, intervalMs);
-                    _lastSentValues[config.Id] = tcodeValue;
+                    _lastSentByAxis[config.Ordinal] = tcodeValue;
                 }
                 continue;
             }
@@ -636,10 +736,12 @@ public class TCodeService : IDisposable
             // --- Random fill ---
             if (config.FillMode == AxisFillMode.Random)
             {
-                if (!_randomGenerators.TryGetValue(config.Id, out var generator))
+                var idx = config.Ordinal;
+                var generator = _randomGenByAxis[idx];
+                if (generator == null)
                 {
                     generator = new RandomPatternGenerator(config.Min, config.Max);
-                    _randomGenerators[config.Id] = generator;
+                    _randomGenByAxis[idx] = generator;
                 }
                 generator.SetRange(config.Min, config.Max);
 
@@ -658,10 +760,9 @@ public class TCodeService : IDisposable
                 {
                     // Normalize time to same scale as stroke distance (~200 units per cycle)
                     // At 1 Hz fill speed, one second = 200 progress units
-                    if (!_cumulativeFillTime.TryGetValue(config.Id, out var cumTime))
-                        cumTime = 0;
+                    var cumTime = _cumulativeFillByAxis[idx];
                     cumTime += config.FillSpeedHz * elapsedSec * 200.0;
-                    _cumulativeFillTime[config.Id] = cumTime;
+                    _cumulativeFillByAxis[idx] = cumTime;
                     progress = cumTime;
                 }
 
@@ -672,17 +773,19 @@ public class TCodeService : IDisposable
                 targetVal = Math.Clamp(targetVal, 0, 999);
                 targetVal = ApplyPositionOffset(config, targetVal);
 
-                var randomVal = ApplyRampUp(config.Id, targetVal);
-                if (IsDirty(config.Id, randomVal))
+                var randomVal = ApplyRampUp(idx, targetVal);
+                if (IsDirty(idx, randomVal))
                 {
                     AppendCommand(config, randomVal, intervalMs);
-                    _lastSentValues[config.Id] = randomVal;
+                    _lastSentByAxis[idx] = randomVal;
                 }
                 continue;
             }
 
             // --- Waveform fill (Triangle, Sine, Saw, etc.) ---
             {
+                var idx = config.Ordinal;
+
                 // When synced to stroke, only move if stroke script is loaded
                 if (config.SyncWithStroke && config.Id != "L0" && !hasStrokeScript)
                 {
@@ -701,10 +804,9 @@ public class TCodeService : IDisposable
                 else
                 {
                     // Independent: accumulate time based on fill speed
-                    if (!_cumulativeFillTime.TryGetValue(config.Id, out var cumTime))
-                        cumTime = 0;
+                    var cumTime = _cumulativeFillByAxis[idx];
                     cumTime += config.FillSpeedHz * elapsedSec;
-                    _cumulativeFillTime[config.Id] = cumTime;
+                    _cumulativeFillByAxis[idx] = cumTime;
                     fillTime = cumTime;
                 }
 
@@ -715,11 +817,11 @@ public class TCodeService : IDisposable
                 position = ClampPitchFillPosition(config, position);
                 var targetVal = ApplyPositionOffset(config, PositionToTCode(config, position));
 
-                var finalVal = ApplyRampUp(config.Id, targetVal);
-                if (IsDirty(config.Id, finalVal))
+                var finalVal = ApplyRampUp(idx, targetVal);
+                if (IsDirty(idx, finalVal))
                 {
                     AppendCommand(config, finalVal, intervalMs);
-                    _lastSentValues[config.Id] = finalVal;
+                    _lastSentByAxis[idx] = finalVal;
                 }
             }
         }
@@ -736,20 +838,21 @@ public class TCodeService : IDisposable
     /// <summary>
     /// Applies exponential ramp-up blend from midpoint (500) to target.
     /// </summary>
-    private int ApplyRampUp(string axisId, int targetVal)
+    private int ApplyRampUp(int ordinal, int targetVal)
     {
-        if (!_rampingAxes.TryGetValue(axisId, out var blend))
+        var blend = _rampingByAxis[ordinal];
+        if (double.IsNaN(blend))
             return targetVal;
 
         blend += (1.0 - blend) * 0.04;
 
         if (blend >= 0.99)
         {
-            _rampingAxes.Remove(axisId);
+            _rampingByAxis[ordinal] = double.NaN;
             return targetVal;
         }
 
-        _rampingAxes[axisId] = blend;
+        _rampingByAxis[ordinal] = blend;
         var blendedVal = (int)Math.Round(500.0 + (targetVal - 500.0) * blend);
         return Math.Clamp(blendedVal, 0, 999);
     }
@@ -760,7 +863,9 @@ public class TCodeService : IDisposable
     /// </summary>
     private void ProcessReturnToCenter(AxisConfig config, int intervalMs)
     {
-        if (!_returningAxes.TryGetValue(config.Id, out var currentPos))
+        var idx = config.Ordinal;
+        var currentPos = _returningByAxis[idx];
+        if (double.IsNaN(currentPos))
             return;
 
         var newPos = currentPos + (500.0 - currentPos) * 0.04;
@@ -769,18 +874,18 @@ public class TCodeService : IDisposable
 
         if (Math.Abs(newPos - 500.0) < 1.0)
         {
-            _returningAxes.Remove(config.Id);
+            _returningByAxis[idx] = double.NaN;
             newVal = 500;
         }
         else
         {
-            _returningAxes[config.Id] = newPos;
+            _returningByAxis[idx] = newPos;
         }
 
-        if (IsDirty(config.Id, newVal))
+        if (IsDirty(idx, newVal))
         {
             AppendCommand(config, newVal, intervalMs);
-            _lastSentValues[config.Id] = newVal;
+            _lastSentByAxis[idx] = newVal;
         }
     }
 
@@ -852,8 +957,12 @@ public class TCodeService : IDisposable
     /// </summary>
     private bool HasActiveFillModes()
     {
-        return _returningAxes.Count > 0
-            || _hasActiveFillConfigs;
+        for (var i = 0; i < _axisCount; i++)
+        {
+            if (!double.IsNaN(_returningByAxis[i]))
+                return true;
+        }
+        return _hasActiveFillConfigs;
     }
 
     /// <summary>
@@ -869,6 +978,21 @@ public class TCodeService : IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Returns the ordinal index for a given axis ID string.
+    /// Used by non-hot-path methods that receive axis IDs from external callers.
+    /// Returns -1 if the axis is not found.
+    /// </summary>
+    private int GetOrdinalForId(string axisId)
+    {
+        for (var i = 0; i < _axisConfigs.Count; i++)
+        {
+            if (_axisConfigs[i].Id == axisId)
+                return _axisConfigs[i].Ordinal;
+        }
+        return -1;
     }
 
     // ===== Helpers =====
@@ -937,12 +1061,13 @@ public class TCodeService : IDisposable
     /// <summary>
     /// Returns <c>true</c> if the axis value changed by ≥1 since last transmission.
     /// </summary>
-    /// <param name="axisId">The axis to check.</param>
+    /// <param name="ordinal">The axis ordinal to check.</param>
     /// <param name="tcodeValue">The proposed TCode value.</param>
     /// <returns><c>true</c> if the value differs from the last sent value.</returns>
-    internal bool IsDirty(string axisId, int tcodeValue)
+    internal bool IsDirty(int ordinal, int tcodeValue)
     {
-        if (!_lastSentValues.TryGetValue(axisId, out var last))
+        var last = _lastSentByAxis[ordinal];
+        if (last < 0)
             return true;
         return Math.Abs(last - tcodeValue) >= 1;
     }
@@ -970,7 +1095,7 @@ public class TCodeService : IDisposable
         var config = FindAxisConfig(axisId);
         if (config == null || _transport?.IsConnected != true) return;
         var command = FormatTCodeCommand(config, 500, 500) + "\n";
-        _lastSentValues.Remove(axisId);
+        _lastSentByAxis[config.Ordinal] = -1;
         Volatile.Write(ref _pendingDirectCommand, command);
     }
 
@@ -990,7 +1115,7 @@ public class TCodeService : IDisposable
         var offsetTcode = ApplyPositionOffset(config, baseTcode);
 
         var command = FormatTCodeCommand(config, offsetTcode, 200) + "\n";
-        _lastSentValues[axisId] = offsetTcode;
+        _lastSentByAxis[config.Ordinal] = offsetTcode;
         Volatile.Write(ref _pendingDirectCommand, command);
     }
 
@@ -1017,7 +1142,7 @@ public class TCodeService : IDisposable
             // Start from the 50% midpoint, then apply the user's position offset
             var homeTcode = ApplyPositionOffset(config, PositionToTCode(config, 50.0));
             parts.Add(FormatTCodeCommand(config, homeTcode, HomingDurationMs));
-            _lastSentValues[config.Id] = homeTcode;
+            _lastSentByAxis[config.Ordinal] = homeTcode;
         }
 
         Volatile.Write(ref _pendingDirectCommand, string.Join(" ", parts) + "\n");

--- a/tests/Vido.Tests/FunscriptServiceTests.cs
+++ b/tests/Vido.Tests/FunscriptServiceTests.cs
@@ -448,86 +448,93 @@ public class FunscriptServiceTests : IDisposable
     public void Interpolation_EmptyActions_Returns50()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData { AxisId = "L0" };
 
-        Assert.Equal(50.0, service.GetPosition(script, 500, "L0"));
+        Assert.Equal(50.0, service.GetPosition(script, 500, 0));
     }
 
     [Fact]
     public void Interpolation_SingleAction_ReturnsItsPos()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
             Actions = [new FunscriptAction(1000, 75)]
         };
 
-        Assert.Equal(75.0, service.GetPosition(script, 500, "L0"));
-        Assert.Equal(75.0, service.GetPosition(script, 1500, "L0"));
+        Assert.Equal(75.0, service.GetPosition(script, 500, 0));
+        Assert.Equal(75.0, service.GetPosition(script, 1500, 0));
     }
 
     [Fact]
     public void Interpolation_BeforeFirstAction_ReturnsFirstPos()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
             Actions = [new FunscriptAction(1000, 25), new FunscriptAction(2000, 75)]
         };
 
-        Assert.Equal(25.0, service.GetPosition(script, 0, "L0"));
-        Assert.Equal(25.0, service.GetPosition(script, 999, "L0"));
+        Assert.Equal(25.0, service.GetPosition(script, 0, 0));
+        Assert.Equal(25.0, service.GetPosition(script, 999, 0));
     }
 
     [Fact]
     public void Interpolation_AfterLastAction_ReturnsLastPos()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
             Actions = [new FunscriptAction(1000, 25), new FunscriptAction(2000, 75)]
         };
 
-        Assert.Equal(75.0, service.GetPosition(script, 2000, "L0"));
-        Assert.Equal(75.0, service.GetPosition(script, 5000, "L0"));
+        Assert.Equal(75.0, service.GetPosition(script, 2000, 0));
+        Assert.Equal(75.0, service.GetPosition(script, 5000, 0));
     }
 
     [Fact]
     public void Interpolation_ExactMatch_ReturnsExactPos()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
             Actions = [new FunscriptAction(0, 0), new FunscriptAction(1000, 100), new FunscriptAction(2000, 0)]
         };
 
-        Assert.Equal(0.0, service.GetPosition(script, 0, "L0"));
-        Assert.Equal(100.0, service.GetPosition(script, 1000, "L0"));
+        Assert.Equal(0.0, service.GetPosition(script, 0, 0));
+        Assert.Equal(100.0, service.GetPosition(script, 1000, 0));
     }
 
     [Fact]
     public void Interpolation_Midpoint_LinearlyInterpolated()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
             Actions = [new FunscriptAction(0, 0), new FunscriptAction(1000, 100)]
         };
 
-        Assert.Equal(50.0, service.GetPosition(script, 500, "L0"));
-        Assert.Equal(25.0, service.GetPosition(script, 250, "L0"));
-        Assert.Equal(75.0, service.GetPosition(script, 750, "L0"));
+        Assert.Equal(50.0, service.GetPosition(script, 500, 0));
+        Assert.Equal(25.0, service.GetPosition(script, 250, 0));
+        Assert.Equal(75.0, service.GetPosition(script, 750, 0));
     }
 
     [Fact]
     public void Interpolation_SequentialCalls_UseCachedIndex()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
@@ -541,15 +548,16 @@ public class FunscriptServiceTests : IDisposable
         };
 
         // Sequential forward calls should use cached index
-        Assert.Equal(50.0, service.GetPosition(script, 500, "L0"));
-        Assert.Equal(50.0, service.GetPosition(script, 1500, "L0"));
-        Assert.Equal(50.0, service.GetPosition(script, 2500, "L0"));
+        Assert.Equal(50.0, service.GetPosition(script, 500, 0));
+        Assert.Equal(50.0, service.GetPosition(script, 1500, 0));
+        Assert.Equal(50.0, service.GetPosition(script, 2500, 0));
     }
 
     [Fact]
     public void Interpolation_SeekBackward_FallsBackToBinarySearch()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
@@ -563,8 +571,8 @@ public class FunscriptServiceTests : IDisposable
         };
 
         // Go to end, then seek back
-        service.GetPosition(script, 2500, "L0");
-        var result = service.GetPosition(script, 500, "L0");
+        service.GetPosition(script, 2500, 0);
+        var result = service.GetPosition(script, 500, 0);
 
         Assert.Equal(50.0, result);
     }
@@ -573,6 +581,7 @@ public class FunscriptServiceTests : IDisposable
     public void Interpolation_ResetIndices_ClearsCache()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
@@ -584,11 +593,11 @@ public class FunscriptServiceTests : IDisposable
             ]
         };
 
-        service.GetPosition(script, 1500, "L0");
+        service.GetPosition(script, 1500, 0);
         service.ResetIndices();
 
         // After reset, should still work correctly
-        var result = service.GetPosition(script, 500, "L0");
+        var result = service.GetPosition(script, 500, 0);
         Assert.Equal(50.0, result);
     }
 
@@ -596,6 +605,7 @@ public class FunscriptServiceTests : IDisposable
     public void Interpolation_DifferentAxes_IndependentCaches()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(2);
         var l0 = new FunscriptData
         {
             AxisId = "L0",
@@ -607,8 +617,8 @@ public class FunscriptServiceTests : IDisposable
             Actions = [new FunscriptAction(0, 100), new FunscriptAction(1000, 0)]
         };
 
-        var posL0 = service.GetPosition(l0, 500, "L0");
-        var posR0 = service.GetPosition(r0, 500, "R0");
+        var posL0 = service.GetPosition(l0, 500, 0);
+        var posR0 = service.GetPosition(r0, 500, 1);
 
         Assert.Equal(50.0, posL0);
         Assert.Equal(50.0, posR0);
@@ -618,6 +628,7 @@ public class FunscriptServiceTests : IDisposable
     public void Interpolation_ZeroRange_ReturnsFirstPos()
     {
         var service = new InterpolationService();
+        service.SetAxisCount(1);
         var script = new FunscriptData
         {
             AxisId = "L0",
@@ -625,7 +636,7 @@ public class FunscriptServiceTests : IDisposable
         };
 
         // Same timestamp — zero range, should return first pos
-        var result = service.GetPosition(script, 1000, "L0");
+        var result = service.GetPosition(script, 1000, 0);
         Assert.Equal(25.0, result);
     }
 

--- a/tests/Vido.Tests/TCodeEngineTests.cs
+++ b/tests/Vido.Tests/TCodeEngineTests.cs
@@ -132,23 +132,26 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void IsDirty_FirstValue_ReturnsTrue()
     {
-        Assert.True(_service.IsDirty("L0", 500));
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
+        Assert.True(_service.IsDirty(0, 500));
     }
 
     [Fact]
     public void IsDirty_SameValue_ReturnsFalse()
     {
         // Simulate having sent a value by using reflection or internal access
-        // Since IsDirty depends on _lastSentValues which is private,
+        // Since IsDirty depends on _lastSentByAxis which is private,
         // we test it through the public API flow
-        Assert.True(_service.IsDirty("L0", 500));
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
+        Assert.True(_service.IsDirty(0, 500));
     }
 
     [Fact]
     public void IsDirty_DifferentAxis_ReturnsTrue()
     {
-        Assert.True(_service.IsDirty("L0", 500));
-        Assert.True(_service.IsDirty("R0", 500));
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0(), MakeR0() });
+        Assert.True(_service.IsDirty(0, 500));
+        Assert.True(_service.IsDirty(1, 500));
     }
 
     // ═══════════════════════════════════════════════
@@ -347,6 +350,7 @@ public class TCodeEngineTests : IDisposable
     {
         Assert.False(_service.HasScriptsLoaded);
 
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
             ["L0"] = MakeScript((0, 0), (1000, 100))
@@ -358,6 +362,7 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void SetScripts_EmptyDictionary_ClearsScripts()
     {
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
             ["L0"] = MakeScript((0, 0), (1000, 100))
@@ -377,6 +382,7 @@ public class TCodeEngineTests : IDisposable
     {
         var emptyScript = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] };
 
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
             ["L0"] = emptyScript
@@ -393,11 +399,11 @@ public class TCodeEngineTests : IDisposable
     public void SetScripts_EmptyActionsL0_InterpolatesWithoutError()
     {
         var emptyScript = new FunscriptData { AxisId = "L0", FilePath = "", Actions = [] };
+        _service.SetAxisConfigs([MakeL0()]);
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
             ["L0"] = emptyScript
         });
-        _service.SetAxisConfigs([MakeL0()]);
         _service.SetPlaying(true);
         _service.SetTime(1000);
 
@@ -413,6 +419,8 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void SetScripts_ClearThenEmptyL0_ReplacesPriorState()
     {
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
+
         // Load a real script
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
@@ -471,6 +479,7 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void IsFunscriptPlaying_WithScripts_ReturnsTrue()
     {
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
             ["L0"] = MakeScript((0, 0), (1000, 100))
@@ -486,6 +495,7 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void StartTestAxis_MarksAsTesting()
     {
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.StartTestAxis("L0", 1.0);
         Assert.True(_service.IsAxisTesting("L0"));
     }
@@ -496,6 +506,7 @@ public class TCodeEngineTests : IDisposable
         string? stoppedId = null;
         _service.TestAxisStopped += id => stoppedId = id;
 
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.StartTestAxis("L0", 1.0);
         _service.StopTestAxis("L0");
 
@@ -509,6 +520,7 @@ public class TCodeEngineTests : IDisposable
         bool allStopped = false;
         _service.AllTestsStopped += () => allStopped = true;
 
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0(), MakeR0() });
         _service.StartTestAxis("L0", 1.0);
         _service.StartTestAxis("R0", 1.0);
         _service.StopAllTestAxes();
@@ -537,6 +549,7 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void UpdateTestSpeed_DoesNotThrow()
     {
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.StartTestAxis("L0", 1.0);
         _service.UpdateTestSpeed("L0", 2.5);
         Assert.True(_service.IsAxisTesting("L0"));
@@ -545,6 +558,7 @@ public class TCodeEngineTests : IDisposable
     [Fact]
     public void StartTestAxis_ClampsSpeed()
     {
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         // Speed should be clamped to 0.1-5.0
         _service.StartTestAxis("L0", 0.01);
         Assert.True(_service.IsAxisTesting("L0"));
@@ -560,6 +574,7 @@ public class TCodeEngineTests : IDisposable
         bool allStopped = false;
         _service.AllTestsStopped += () => allStopped = true;
 
+        _service.SetAxisConfigs(new List<AxisConfig> { MakeL0() });
         _service.SetScripts(new Dictionary<string, FunscriptData>
         {
             ["L0"] = MakeScript((0, 0), (1000, 100))


### PR DESCRIPTION
* Replace `Dictionary<string, ...>` fields with fixed-size arrays indexed by `AxisConfig.Ordinal` in `TCodeService` and `InterpolationService`.
* Add `Ordinal` property to `AxisConfig`, assigned in `SetAxisConfigs`.
* Change `InterpolationService.GetPosition` signature from `string axisId` to `int axisOrdinal`.
* Replace `ConcurrentDictionary<string, int>` index cache with `int[]` in `InterpolationService`.
* Introduce `InterpolationService.SetAxisCount()` for managing axis count.
* Update `IsDirty` method to use integer ordinals instead of string-based lookups.
* Add `GetOrdinalForId()` helper for non-hot-path string-to-ordinal resolution.
* Update tests to call `SetAxisConfigs` before `SetScripts`/`StartTestAxis` and use integer ordinals.
* Add `InternalsVisibleTo` attributes for `Vido.Services` and `Vido.Tests` in `Vido.Core.csproj`.