### PR TITLE
feat(settings): add new settings and refresh functionality

### DIFF
--- a/src/Vido.Core/Settings/AppSettingsStore.cs
+++ b/src/Vido.Core/Settings/AppSettingsStore.cs
@@ -39,6 +39,11 @@ public sealed class AppSettingsStore : ISettingsStore
             ["osr2.outputRate"] = () => (double)Settings.Osr2OutputRate,
             ["osr2.globalOffset"] = () => (double)Settings.Osr2GlobalOffset,
             ["osr2.visualizerWindowDuration"] = () => Settings.Osr2VisualizerWindowDuration.ToString(),
+            ["general.toastDuration"] = () => Settings.ToastDurationSeconds,
+            ["playback.fullscreenAutoHide"] = () => Settings.FullscreenAutoHideSeconds,
+            ["playback.fullscreenShowVideoName"] = () => Settings.FullscreenShowVideoName,
+            ["playback.resumePlaybackPrompt"] = () => Settings.ResumePlaybackPrompt,
+            ["playlist.autoSave"] = () => Settings.PlaylistAutoSave,
             ["updates.autocheck"] = () => Settings.AutoCheckUpdates,
         };
 
@@ -104,6 +109,31 @@ public sealed class AppSettingsStore : ISettingsStore
             {
                 if (int.TryParse(v?.ToString(), out var dur))
                     Settings.Osr2VisualizerWindowDuration = dur;
+                _settingsService.QueueSave();
+            },
+            ["general.toastDuration"] = v =>
+            {
+                Settings.ToastDurationSeconds = Math.Clamp(Convert.ToDouble(v), 1.0, 10.0);
+                _settingsService.QueueSave();
+            },
+            ["playback.fullscreenAutoHide"] = v =>
+            {
+                Settings.FullscreenAutoHideSeconds = Math.Clamp(Convert.ToDouble(v), 1.0, 30.0);
+                _settingsService.QueueSave();
+            },
+            ["playback.fullscreenShowVideoName"] = v =>
+            {
+                Settings.FullscreenShowVideoName = Convert.ToBoolean(v);
+                _settingsService.QueueSave();
+            },
+            ["playback.resumePlaybackPrompt"] = v =>
+            {
+                Settings.ResumePlaybackPrompt = Convert.ToBoolean(v);
+                _settingsService.QueueSave();
+            },
+            ["playlist.autoSave"] = v =>
+            {
+                Settings.PlaylistAutoSave = Convert.ToBoolean(v);
                 _settingsService.QueueSave();
             },
             ["updates.autocheck"] = v =>

--- a/src/Vido.ViewModels/Osr2Plus/AxisControlViewModel.cs
+++ b/src/Vido.ViewModels/Osr2Plus/AxisControlViewModel.cs
@@ -474,10 +474,21 @@ public class AxisControlViewModel : INotifyPropertyChanged
         };
         OnPropertyChanged(nameof(AvailableProfiles));
 
-        // Auto-select Default profile on startup
+        // Auto-select Default profile on startup — show it in dropdown
+        // but don't apply its values (let persisted settings take precedence)
         if (_selectedProfile is null)
         {
-            SelectedProfile = _profileService.FindByName("Default");
+            var defaultProfile = _profileService.FindByName("Default");
+            if (defaultProfile is not null)
+            {
+                _selectedProfile = defaultProfile;
+                OnPropertyChanged(nameof(SelectedProfile));
+                OnPropertyChanged(nameof(CanDeleteSelectedProfile));
+                OnPropertyChanged(nameof(CanRenameSelectedProfile));
+
+                var currentAxes = CaptureCurrentAxes();
+                IsProfileModified = !defaultProfile.MatchesAxes(currentAxes);
+            }
         }
     }
 

--- a/src/Vido.ViewModels/SettingsViewModel.cs
+++ b/src/Vido.ViewModels/SettingsViewModel.cs
@@ -399,4 +399,24 @@ public partial class SettingsViewModel : ObservableObject
             }
         }
     }
+
+    /// <summary>
+    /// Reloads a single setting's displayed value from the backing store.
+    /// Used for bidirectional sync when a setting changes outside the Settings panel.
+    /// </summary>
+    /// <param name="key">The setting key (e.g. "osr2.outputRate").</param>
+    public void RefreshSetting(string key)
+    {
+        foreach (var category in AllCategories)
+        {
+            foreach (var item in category.Settings)
+            {
+                if (string.Equals(item.Id, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    item.Reload();
+                    return;
+                }
+            }
+        }
+    }
 }

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1623,6 +1623,16 @@ public partial class MainWindow : Window
                 if (statusItem is not null)
                     statusItem.Text = _osr2SidebarVm.StatusText;
             }
+
+            if (e.PropertyName == nameof(Osr2PlusSidebarViewModel.OutputRateHz))
+            {
+                _settingsPage?.RefreshSetting("osr2.outputRate");
+            }
+
+            if (e.PropertyName == nameof(Osr2PlusSidebarViewModel.GlobalOffsetMs))
+            {
+                _settingsPage?.RefreshSetting("osr2.globalOffset");
+            }
         };
 
         // â”€â”€ Wire Script Changes to Visualizer â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
@@ -2441,6 +2451,16 @@ public partial class MainWindow : Window
                     "Screenshots");
                 _appSettingsStore.Set("screenshot.directory", defaultDir);
             }
+        }
+        else if (key.Equals("osr2.outputRate", StringComparison.OrdinalIgnoreCase))
+        {
+            if (_osr2SidebarVm is not null)
+                _osr2SidebarVm.OutputRateHz = _settingsService.Current.Osr2OutputRate;
+        }
+        else if (key.Equals("osr2.globalOffset", StringComparison.OrdinalIgnoreCase))
+        {
+            if (_osr2SidebarVm is not null)
+                _osr2SidebarVm.GlobalOffsetMs = _settingsService.Current.Osr2GlobalOffset;
         }
     }
 

--- a/src/Vido.Views/Panels/SettingsPage.xaml.cs
+++ b/src/Vido.Views/Panels/SettingsPage.xaml.cs
@@ -31,6 +31,12 @@ public partial class SettingsPage : UserControl
         UpdateNoResultsVisibility();
     }
 
+    /// <summary>
+    /// Reloads a single setting's displayed value from the backing store.
+    /// </summary>
+    /// <param name="key">The setting key (e.g. "osr2.outputRate").</param>
+    public void RefreshSetting(string key) => _viewModel.RefreshSetting(key);
+
     private void OnSearchTextChanged(object sender, TextChangedEventArgs e)
     {
         _viewModel.SearchText = SearchBox.Text;

--- a/tests/Vido.Tests/AppSettingsStoreTests.cs
+++ b/tests/Vido.Tests/AppSettingsStoreTests.cs
@@ -238,4 +238,89 @@ public sealed class AppSettingsStoreTests
     {
         Assert.Throws<ArgumentNullException>(() => new AppSettingsStore(null!));
     }
+
+    // ── Toast Duration ──
+
+    [Fact]
+    public void Get_ToastDuration_ReturnsValue()
+    {
+        _settings.ToastDurationSeconds = 5.0;
+        Assert.Equal(5.0, _store.Get("general.toastDuration", 0.0));
+    }
+
+    [Fact]
+    public void Set_ToastDuration_ClampsAndSaves()
+    {
+        _store.Set("general.toastDuration", 15.0);
+        Assert.Equal(10.0, _settings.ToastDurationSeconds);
+        _settingsService.Received().QueueSave();
+    }
+
+    // ── Fullscreen Auto-Hide ──
+
+    [Fact]
+    public void Get_FullscreenAutoHide_ReturnsValue()
+    {
+        _settings.FullscreenAutoHideSeconds = 7.0;
+        Assert.Equal(7.0, _store.Get("playback.fullscreenAutoHide", 0.0));
+    }
+
+    [Fact]
+    public void Set_FullscreenAutoHide_ClampsAndSaves()
+    {
+        _store.Set("playback.fullscreenAutoHide", 50.0);
+        Assert.Equal(30.0, _settings.FullscreenAutoHideSeconds);
+        _settingsService.Received().QueueSave();
+    }
+
+    // ── Fullscreen Show Video Name ──
+
+    [Fact]
+    public void Get_FullscreenShowVideoName_ReturnsValue()
+    {
+        _settings.FullscreenShowVideoName = false;
+        Assert.False(_store.Get("playback.fullscreenShowVideoName", true));
+    }
+
+    [Fact]
+    public void Set_FullscreenShowVideoName_UpdatesAndSaves()
+    {
+        _store.Set("playback.fullscreenShowVideoName", false);
+        Assert.False(_settings.FullscreenShowVideoName);
+        _settingsService.Received().QueueSave();
+    }
+
+    // ── Resume Playback Prompt ──
+
+    [Fact]
+    public void Get_ResumePlaybackPrompt_ReturnsValue()
+    {
+        _settings.ResumePlaybackPrompt = false;
+        Assert.False(_store.Get("playback.resumePlaybackPrompt", true));
+    }
+
+    [Fact]
+    public void Set_ResumePlaybackPrompt_UpdatesAndSaves()
+    {
+        _store.Set("playback.resumePlaybackPrompt", false);
+        Assert.False(_settings.ResumePlaybackPrompt);
+        _settingsService.Received().QueueSave();
+    }
+
+    // ── Playlist Auto-Save ──
+
+    [Fact]
+    public void Get_PlaylistAutoSave_ReturnsValue()
+    {
+        _settings.PlaylistAutoSave = true;
+        Assert.True(_store.Get("playlist.autoSave", false));
+    }
+
+    [Fact]
+    public void Set_PlaylistAutoSave_UpdatesAndSaves()
+    {
+        _store.Set("playlist.autoSave", true);
+        Assert.True(_settings.PlaylistAutoSave);
+        _settingsService.Received().QueueSave();
+    }
 }

--- a/tests/Vido.Tests/AxisControlViewModelProfileTests.cs
+++ b/tests/Vido.Tests/AxisControlViewModelProfileTests.cs
@@ -368,4 +368,68 @@ public class AxisControlViewModelProfileTests : IDisposable
         Assert.NotNull(_profileService.FindByName("Default"));
         Assert.Null(_profileService.FindByName("Renamed"));
     }
+
+    // ── SetProfileService preserves persisted settings ────────────────
+
+    [Fact]
+    public void SetProfileService_PreservesPersistedAxisSettings()
+    {
+        // Arrange: persisted settings differ from Default profile
+        _settings.Osr2AxisSettings["R0"] = new AxisSettingsData
+        {
+            Min = 20, Max = 80, FillMode = "Sine", SyncWithStroke = true, FillSpeedHz = 1.5
+        };
+
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+
+        // Act: attach profile service (auto-selects Default)
+        var logService = NSubstitute.Substitute.For<Core.Logging.ILogService>();
+        var profileService = new FillProfileService(logService);
+        vm.SetProfileService(profileService);
+
+        // Assert: persisted values survive, not overwritten by Default profile
+        var r0 = vm.AxisCards[1]; // R0
+        Assert.Equal(20, r0.Min);
+        Assert.Equal(80, r0.Max);
+        Assert.Equal(AxisFillMode.Sine, r0.FillMode);
+        Assert.True(r0.SyncWithStroke);
+        Assert.Equal(1.5, r0.FillSpeedHz, 3);
+    }
+
+    [Fact]
+    public void SetProfileService_SetsIsProfileModified_WhenSettingsDiffer()
+    {
+        _settings.Osr2AxisSettings["R0"] = new AxisSettingsData
+        {
+            Min = 20, Max = 80, FillMode = "Sine", SyncWithStroke = true
+        };
+
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var logService = NSubstitute.Substitute.For<Core.Logging.ILogService>();
+        vm.SetProfileService(new FillProfileService(logService));
+
+        Assert.True(vm.IsProfileModified);
+    }
+
+    [Fact]
+    public void SetProfileService_NoModified_WhenSettingsMatchDefault()
+    {
+        // Default profile: Min=0, Max=100, FillMode=None, SyncWithStroke=false
+        // AxisSettingsData defaults: Min=0, Max=100, Enabled=true, FillMode=None, SyncWithStroke=true
+        // Need to set SyncWithStroke=false to match the Default profile
+        foreach (var key in new[] { "L0", "R0", "R1", "R2" })
+        {
+            _settings.Osr2AxisSettings[key] = new AxisSettingsData
+            {
+                Min = 0, Max = 100, Enabled = true,
+                FillMode = "None", SyncWithStroke = false, FillSpeedHz = 1.0
+            };
+        }
+
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var logService = NSubstitute.Substitute.For<Core.Logging.ILogService>();
+        vm.SetProfileService(new FillProfileService(logService));
+
+        Assert.False(vm.IsProfileModified);
+    }
 }

--- a/tests/Vido.Tests/SettingsViewModelTests.cs
+++ b/tests/Vido.Tests/SettingsViewModelTests.cs
@@ -279,4 +279,34 @@ public sealed class SettingsViewModelTests
 
         Assert.True(dirItem.IsSettingVisible);
     }
+
+    // — RefreshSetting —
+
+    [Fact]
+    public void RefreshSetting_UpdatesDisplayedValue()
+    {
+        var settings = new AppSettings { Osr2OutputRate = 100 };
+        var svc = Substitute.For<ISettingsService>();
+        svc.Current.Returns(settings);
+        var store = new AppSettingsStore(svc);
+        var vm = new SettingsViewModel(svc, store);
+
+        var osr2 = vm.AllCategories.First(c => c.Name == "OSR2+");
+        var rateItem = osr2.Settings.First(s => s.Id == "osr2.outputRate");
+        Assert.Equal("100", rateItem.StringValue);
+
+        // Mutate AppSettings directly (simulating sidebar change)
+        settings.Osr2OutputRate = 150;
+        vm.RefreshSetting("osr2.outputRate");
+
+        Assert.Equal("150", rateItem.StringValue);
+    }
+
+    [Fact]
+    public void RefreshSetting_UnknownKey_DoesNotThrow()
+    {
+        var vm = CreateViewModel();
+        var ex = Record.Exception(() => vm.RefreshSetting("nonexistent.key"));
+        Assert.Null(ex);
+    }
 }


### PR DESCRIPTION
* Introduced new settings for toast duration, fullscreen auto-hide, fullscreen show video name, resume playback prompt, and playlist auto-save.
* Implemented refresh functionality for settings to sync displayed values when changed externally.
* Added unit tests to ensure new settings behave as expected.