### PR TITLE
feat(axis): implement script opening and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Vido project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **vido-250**: Implemented validated script opening with TCode push. Replaced `AxisCardViewModel.ExecuteOpenScript` local parsing with `ScriptOpenRequested` event — the parent `AxisControlViewModel` now validates axis compatibility, parses the file (suffix-match or multi-axis fallback), and pushes to TCodeService. Added `FunscriptMatcher.GetAxisIdForFile()` static method for suffix-based axis detection. Added `IToastService` property on `AxisControlViewModel` for error feedback. Removed `ParseFileFunc` from `AxisCardViewModel`. Added `SetManualScript()` internal method. Updated 3 existing tests, added 8 new script-open tests and 8 `GetAxisIdForFile` theory cases (16 net new tests).
 - **vido-245**: File explorer now filters out non-video files. Added `FilterVideoFiles()` method to `FileExplorerViewModel` that retains only directories, recognized video files (`FileNode.IsVideoFile`), and files matching `AdditionalAcceptedExtensions`. Applied in all 4 tree-building code paths: `OpenFolderAsync`, `ExpandNodeAsync`, `RescanFolderAsync`, and `RestoreExpandedStateAsync`. Added 5 new unit tests covering filtering in open/expand/rescan paths, `AdditionalAcceptedExtensions` retention, and empty directory preservation. Updated 15 existing tests from `.txt` to `.mp4` extensions.
 
 ### Changed

--- a/src/Vido.Services/Osr2Plus/FunscriptMatcher.cs
+++ b/src/Vido.Services/Osr2Plus/FunscriptMatcher.cs
@@ -23,6 +23,38 @@ public class FunscriptMatcher
     };
 
     /// <summary>
+    /// Determines the axis ID from a funscript filename using suffix conventions.
+    /// Returns "L0" for base ".funscript" files, "R0" for ".twist.funscript", etc.
+    /// </summary>
+    /// <param name="filePath">Path to the funscript file.</param>
+    /// <returns>The axis ID ("L0", "R0", "R1", "R2").</returns>
+    public static string GetAxisIdForFile(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        if (string.IsNullOrEmpty(fileName))
+            return "L0";
+
+        // Strip .funscript extension
+        if (fileName.EndsWith(".funscript", StringComparison.OrdinalIgnoreCase))
+            fileName = fileName[..^".funscript".Length];
+
+        // Check for axis suffix: "something.twist" → "twist"
+        var dotIndex = fileName.LastIndexOf('.');
+        if (dotIndex >= 0)
+        {
+            var suffix = fileName[(dotIndex + 1)..];
+            foreach (var (s, axisId) in SuffixToAxis)
+            {
+                if (!string.IsNullOrEmpty(s) &&
+                    string.Equals(suffix, s, StringComparison.OrdinalIgnoreCase))
+                    return axisId;
+            }
+        }
+
+        return "L0";
+    }
+
+    /// <summary>
     /// Finds matching funscript files for the given video file.
     /// Searches the same directory as the video using case-insensitive matching.
     /// </summary>

--- a/src/Vido.ViewModels/Osr2Plus/AxisCardViewModel.cs
+++ b/src/Vido.ViewModels/Osr2Plus/AxisCardViewModel.cs
@@ -25,11 +25,6 @@ public class AxisCardViewModel : INotifyPropertyChanged
     internal Func<string?>? FileDialogFactory { get; set; }
 
     /// <summary>
-    /// Delegate for parsing a funscript file. Injectable for testing.
-    /// </summary>
-    internal Func<string, string, FunscriptData>? ParseFileFunc { get; set; }
-
-    /// <summary>
     /// Raised when axis config changes and the caller should propagate configs to TCodeService.
     /// </summary>
     public event Action? ConfigChanged;
@@ -39,6 +34,12 @@ public class AxisCardViewModel : INotifyPropertyChanged
     /// Carries the axis ID so the parent can deload the script data.
     /// </summary>
     public event Action<string>? ScriptCleared;
+
+    /// <summary>
+    /// Raised when the user selects a funscript file to open.
+    /// Carries (axisId, filePath) for the parent to validate and load.
+    /// </summary>
+    public event Action<string, string>? ScriptOpenRequested;
 
     // ═══════════════════════════════════════════════════════
     //  Identity (read-only from AxisConfig)
@@ -351,6 +352,16 @@ public class AxisCardViewModel : INotifyPropertyChanged
         ScriptFileName = null;
     }
 
+    /// <summary>
+    /// Sets the script as manually opened. Called by the parent after successful validation.
+    /// </summary>
+    /// <param name="filePath">The path of the manually opened funscript file.</param>
+    internal void SetManualScript(string filePath)
+    {
+        IsScriptManual = true;
+        ScriptFileName = filePath;
+    }
+
     // ═══════════════════════════════════════════════════════
     //  Command Implementations
     // ═══════════════════════════════════════════════════════
@@ -360,14 +371,7 @@ public class AxisCardViewModel : INotifyPropertyChanged
         var filePath = FileDialogFactory?.Invoke();
         if (string.IsNullOrEmpty(filePath)) return;
 
-        var data = ParseFileFunc?.Invoke(filePath, AxisId);
-        if (data == null) return;
-
-        ScriptFileName = filePath;
-        IsScriptManual = true;
-
-        // Notify parent to update TCodeService scripts
-        ConfigChanged?.Invoke();
+        ScriptOpenRequested?.Invoke(AxisId, filePath);
     }
 
     private void ExecuteClearScript()

--- a/src/Vido.ViewModels/Osr2Plus/AxisControlViewModel.cs
+++ b/src/Vido.ViewModels/Osr2Plus/AxisControlViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Vido.Core.Models.Osr2Plus;
 using Vido.Core.Settings;
 using Vido.Services.Osr2Plus;
+using Vido.Services.Playlists;
 
 namespace Vido.ViewModels.Osr2Plus;
 
@@ -43,6 +44,12 @@ public class AxisControlViewModel : INotifyPropertyChanged
     /// Raised when any axis configuration changes (min/max/enabled/fill settings).
     /// </summary>
     public event Action? AxisConfigChanged;
+
+    /// <summary>
+    /// Optional toast notification service for displaying user-facing error messages.
+    /// Set after construction by the host since the ViewModel is DI-resolved.
+    /// </summary>
+    public IToastService? ToastService { get; set; }
 
     /// <summary>Raised to request a profile name from the view (save operation).</summary>
     public event EventHandler? RequestProfileName;
@@ -179,9 +186,9 @@ public class AxisControlViewModel : INotifyPropertyChanged
         foreach (var config in _configs)
         {
             var card = new AxisCardViewModel(config, _tcode);
-            card.ParseFileFunc = ParseFileFunc;
             card.ConfigChanged += OnCardConfigChanged;
             card.ScriptCleared += OnCardScriptCleared;
+            card.ScriptOpenRequested += OnCardScriptOpenRequested;
             AxisCards.Add(card);
         }
     }
@@ -427,6 +434,45 @@ public class AxisControlViewModel : INotifyPropertyChanged
     {
         _loadedScripts.Remove(axisId);
         _tcode.ClearAxisScript(axisId);
+        ScriptsChanged?.Invoke(_loadedScripts);
+    }
+
+    private void OnCardScriptOpenRequested(string axisId, string filePath)
+    {
+        var card = AxisCards.FirstOrDefault(c => c.AxisId == axisId);
+        if (card == null) return;
+
+        var fileAxisId = FunscriptMatcher.GetAxisIdForFile(filePath);
+        var fileName = Path.GetFileName(filePath);
+
+        FunscriptData? scriptData = null;
+
+        if (string.Equals(fileAxisId, axisId, StringComparison.OrdinalIgnoreCase))
+        {
+            // Direct suffix match: .pitch.funscript on R2, or .funscript on L0
+            try { scriptData = ParseFileFunc!(filePath, axisId); }
+            catch { /* parse error */ }
+        }
+
+        // If no direct match (or base file on non-L0), try multi-axis
+        if (scriptData == null &&
+            string.Equals(fileAxisId, "L0", StringComparison.OrdinalIgnoreCase))
+        {
+            var multiAxis = TryParseMultiAxisFunc!(filePath);
+            if (multiAxis != null)
+                multiAxis.TryGetValue(axisId, out scriptData);
+        }
+
+        if (scriptData == null || scriptData.Actions.Count == 0)
+        {
+            ToastService?.ShowError($"No {card.AxisName} axis available in \"{fileName}\"");
+            return;
+        }
+
+        // Success — update card, loaded scripts, and push to TCode
+        card.SetManualScript(filePath);
+        _loadedScripts[axisId] = scriptData;
+        _tcode.SetScripts(_loadedScripts);
         ScriptsChanged?.Invoke(_loadedScripts);
     }
 

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1587,6 +1587,7 @@ public partial class MainWindow : Window
         // â”€â”€ Create ViewModels â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         _osr2SidebarVm = new Osr2PlusSidebarViewModel(_tcode, _settingsService, _eventBus, toastService: _toastService);
         _axisControlVm = new AxisControlViewModel(_tcode, _settingsService, parser, matcher);
+        _axisControlVm.ToastService = _toastService;
         var fillProfileService = new FillProfileService(_logService);
         fillProfileService.Load();
         _axisControlVm.SetProfileService(fillProfileService);

--- a/tests/Vido.Tests/Osr2ViewModelTests.cs
+++ b/tests/Vido.Tests/Osr2ViewModelTests.cs
@@ -385,21 +385,22 @@ public class Osr2ViewModelTests : IDisposable
     }
 
     /// <summary>
-    /// Verifies that OpenScriptCommand uses FileDialogFactory and ParseFileFunc.
+    /// Verifies that OpenScriptCommand fires ScriptOpenRequested with axisId and filePath.
     /// </summary>
     [Fact]
-    public void AxisCard_OpenScriptCommand_UsesFactories()
+    public void AxisCard_OpenScriptCommand_FiresScriptOpenRequested()
     {
         var vm = new AxisCardViewModel(MakeL0(), _tcode);
-        var script = MakeScript((0, 0), (1000, 100));
         vm.FileDialogFactory = () => @"C:\videos\custom.funscript";
-        vm.ParseFileFunc = (path, id) => script;
+
+        string? receivedAxisId = null;
+        string? receivedFilePath = null;
+        vm.ScriptOpenRequested += (axisId, filePath) => { receivedAxisId = axisId; receivedFilePath = filePath; };
 
         vm.OpenScriptCommand.Execute(null);
 
-        Assert.Equal(@"C:\videos\custom.funscript", vm.ScriptFileName);
-        Assert.True(vm.IsScriptManual);
-        Assert.True(vm.HasScript);
+        Assert.Equal("L0", receivedAxisId);
+        Assert.Equal(@"C:\videos\custom.funscript", receivedFilePath);
     }
 
     /// <summary>
@@ -411,8 +412,12 @@ public class Osr2ViewModelTests : IDisposable
         var vm = new AxisCardViewModel(MakeL0(), _tcode);
         vm.FileDialogFactory = () => null;
 
+        var fired = false;
+        vm.ScriptOpenRequested += (_, _) => fired = true;
+
         vm.OpenScriptCommand.Execute(null);
 
+        Assert.False(fired);
         Assert.Null(vm.ScriptFileName);
         Assert.False(vm.HasScript);
     }
@@ -424,10 +429,7 @@ public class Osr2ViewModelTests : IDisposable
     public void AxisCard_ClearScriptCommand_ClearsScript()
     {
         var vm = new AxisCardViewModel(MakeL0(), _tcode);
-        var script = MakeScript((0, 0), (1000, 100));
-        vm.FileDialogFactory = () => @"C:\videos\custom.funscript";
-        vm.ParseFileFunc = (path, id) => script;
-        vm.OpenScriptCommand.Execute(null);
+        vm.SetManualScript(@"C:\videos\custom.funscript");
         Assert.True(vm.HasScript);
 
         vm.ClearScriptCommand.Execute(null);
@@ -444,10 +446,7 @@ public class Osr2ViewModelTests : IDisposable
     public void AxisCard_ClearScriptCommand_FiresScriptCleared()
     {
         var vm = new AxisCardViewModel(MakeL0(), _tcode);
-        var script = MakeScript((0, 0), (1000, 100));
-        vm.FileDialogFactory = () => @"C:\videos\custom.funscript";
-        vm.ParseFileFunc = (path, id) => script;
-        vm.OpenScriptCommand.Execute(null);
+        vm.SetManualScript(@"C:\videos\custom.funscript");
 
         string? clearedAxisId = null;
         vm.ScriptCleared += id => clearedAxisId = id;
@@ -739,6 +738,201 @@ public class Osr2ViewModelTests : IDisposable
         vm.AxisCards[0].ClearScriptCommand.Execute(null);
 
         Assert.False(fired);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    //  FunscriptMatcher.GetAxisIdForFile Tests
+    // ═══════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(@"C:\videos\test.funscript", "L0")]
+    [InlineData(@"C:\videos\test.twist.funscript", "R0")]
+    [InlineData(@"C:\videos\test.roll.funscript", "R1")]
+    [InlineData(@"C:\videos\test.pitch.funscript", "R2")]
+    [InlineData(@"C:\videos\test.TWIST.funscript", "R0")]
+    [InlineData(@"C:\videos\test.Pitch.FUNSCRIPT", "R2")]
+    [InlineData(@"test.funscript", "L0")]
+    [InlineData(@"", "L0")]
+    public void FunscriptMatcher_GetAxisIdForFile_MapsCorrectly(string filePath, string expectedAxisId)
+    {
+        Assert.Equal(expectedAxisId, FunscriptMatcher.GetAxisIdForFile(filePath));
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    //  AxisControlViewModel — Script Open Tests
+    // ═══════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Opening a .pitch.funscript on R2 with matching suffix loads and pushes to TCode.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_SuffixMatch_LoadsAndPushes()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var r2Script = MakeScript((0, 0), (1000, 100));
+        vm.ParseFileFunc = (path, id) => r2Script;
+        vm.TryParseMultiAxisFunc = _ => null;
+
+        Dictionary<string, FunscriptData>? received = null;
+        vm.ScriptsChanged += scripts => received = scripts;
+
+        // Simulate opening .pitch.funscript on R2 card (index 3)
+        vm.AxisCards[3].FileDialogFactory = () => @"C:\videos\custom.pitch.funscript";
+        vm.AxisCards[3].OpenScriptCommand.Execute(null);
+
+        Assert.NotNull(received);
+        Assert.True(received.ContainsKey("R2"));
+        Assert.True(vm.AxisCards[3].HasScript);
+        Assert.True(vm.AxisCards[3].IsScriptManual);
+        Assert.Equal(@"C:\videos\custom.pitch.funscript", vm.AxisCards[3].ScriptFileName);
+    }
+
+    /// <summary>
+    /// Opening a base .funscript on R2 extracts R2 data from multi-axis format.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_MultiAxis_ExtractsTargetAxis()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var r2Script = MakeScript((0, 25), (1000, 75));
+        vm.ParseFileFunc = (path, id) => throw new Exception("Should not parse directly");
+        vm.TryParseMultiAxisFunc = _ => new Dictionary<string, FunscriptData>
+        {
+            { "L0", MakeScript((0, 0), (1000, 100)) },
+            { "R2", r2Script }
+        };
+
+        Dictionary<string, FunscriptData>? received = null;
+        vm.ScriptsChanged += scripts => received = scripts;
+
+        vm.AxisCards[3].FileDialogFactory = () => @"C:\videos\custom.funscript";
+        vm.AxisCards[3].OpenScriptCommand.Execute(null);
+
+        Assert.NotNull(received);
+        Assert.True(received.ContainsKey("R2"));
+        Assert.Same(r2Script, received["R2"]);
+    }
+
+    /// <summary>
+    /// Opening a base .funscript on R2 when multi-axis has no R2 data shows toast.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_MultiAxis_NoTargetAxis_ShowsToast()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var toastService = Substitute.For<IToastService>();
+        vm.ToastService = toastService;
+        vm.ParseFileFunc = (path, id) => throw new Exception("Should not parse directly");
+        vm.TryParseMultiAxisFunc = _ => new Dictionary<string, FunscriptData>
+        {
+            { "L0", MakeScript((0, 0), (1000, 100)) }
+        };
+
+        vm.AxisCards[3].FileDialogFactory = () => @"C:\videos\custom.funscript";
+        vm.AxisCards[3].OpenScriptCommand.Execute(null);
+
+        toastService.Received(1).ShowError(
+            Arg.Is<string>(s => s.Contains("Pitch") && s.Contains("custom.funscript")),
+            Arg.Any<string?>());
+        Assert.False(vm.AxisCards[3].HasScript);
+    }
+
+    /// <summary>
+    /// Opening a .twist.funscript on R2 (wrong suffix) shows toast.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_WrongSuffix_ShowsToast()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var toastService = Substitute.For<IToastService>();
+        vm.ToastService = toastService;
+        vm.ParseFileFunc = (path, id) => MakeScript((0, 0), (1000, 100));
+        vm.TryParseMultiAxisFunc = _ => null;
+
+        vm.AxisCards[3].FileDialogFactory = () => @"C:\videos\custom.twist.funscript";
+        vm.AxisCards[3].OpenScriptCommand.Execute(null);
+
+        toastService.Received(1).ShowError(
+            Arg.Is<string>(s => s.Contains("Pitch")),
+            Arg.Any<string?>());
+        Assert.False(vm.AxisCards[3].HasScript);
+    }
+
+    /// <summary>
+    /// Opening a base .funscript on L0 loads root actions directly (suffix match on L0).
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_BaseFunscript_OnL0_LoadsDirectly()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        var l0Script = MakeScript((0, 0), (1000, 100));
+        vm.ParseFileFunc = (path, id) => l0Script;
+        vm.TryParseMultiAxisFunc = _ => null;
+
+        Dictionary<string, FunscriptData>? received = null;
+        vm.ScriptsChanged += scripts => received = scripts;
+
+        vm.AxisCards[0].FileDialogFactory = () => @"C:\videos\custom.funscript";
+        vm.AxisCards[0].OpenScriptCommand.Execute(null);
+
+        Assert.NotNull(received);
+        Assert.True(received.ContainsKey("L0"));
+        Assert.Same(l0Script, received["L0"]);
+        Assert.True(vm.AxisCards[0].IsScriptManual);
+    }
+
+    /// <summary>
+    /// After successful open, card has IsScriptManual = true and correct ScriptFileName.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_SetsManualFlag()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        vm.ParseFileFunc = (path, id) => MakeScript((0, 0), (1000, 100));
+        vm.TryParseMultiAxisFunc = _ => null;
+
+        vm.AxisCards[0].FileDialogFactory = () => @"C:\videos\manual.funscript";
+        vm.AxisCards[0].OpenScriptCommand.Execute(null);
+
+        Assert.True(vm.AxisCards[0].IsScriptManual);
+        Assert.Equal(@"C:\videos\manual.funscript", vm.AxisCards[0].ScriptFileName);
+    }
+
+    /// <summary>
+    /// ScriptsChanged event fires after successful open.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_FiresScriptsChanged()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        vm.ParseFileFunc = (path, id) => MakeScript((0, 0), (1000, 100));
+        vm.TryParseMultiAxisFunc = _ => null;
+
+        var fireCount = 0;
+        vm.ScriptsChanged += _ => fireCount++;
+
+        vm.AxisCards[0].FileDialogFactory = () => @"C:\videos\custom.funscript";
+        vm.AxisCards[0].OpenScriptCommand.Execute(null);
+
+        Assert.Equal(1, fireCount);
+    }
+
+    /// <summary>
+    /// When ToastService is null, opening an incompatible file does not throw.
+    /// </summary>
+    [Fact]
+    public void AxisControl_OpenScript_NoToastService_DoesNotThrow()
+    {
+        var vm = new AxisControlViewModel(_tcode, _settingsService, _parser, _matcher);
+        vm.ToastService = null;
+        vm.ParseFileFunc = (path, id) => MakeScript((0, 0), (1000, 100));
+        vm.TryParseMultiAxisFunc = _ => null;
+
+        vm.AxisCards[3].FileDialogFactory = () => @"C:\videos\custom.twist.funscript";
+
+        var exception = Record.Exception(() => vm.AxisCards[3].OpenScriptCommand.Execute(null));
+
+        Assert.Null(exception);
     }
 
     // ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
- Implement validated script opening with TCode push.
- Replace local parsing in AxisCardViewModel with ScriptOpenRequested event.
- Validate axis compatibility and parse file in AxisControlViewModel.
- Add FunscriptMatcher.GetAxisIdForFile() for suffix-based detection.
- Introduce IToastService for error feedback in AxisControlViewModel.
- Update tests for new functionality and add new test cases.