### PR TITLE
feat(ui): replace hardcoded install path with editable TextBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Vido project will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- **vido-258**: Replaced the read-only hardcoded install path display in `OptionsPage.xaml` with an editable `TextBox` bound to `Options.InstallPath` and a "Browse..." button using `OpenFolderDialog`. Added `BrowseButton_Click` handler in `OptionsPage.xaml.cs`. Browse button styled with `ButtonDefaultBackgroundBrush`/`ButtonBackgroundBrush` hover matching the Install button pattern.
 - **vido-257**: Added `InstallPath` property to `InstallOptions` (defaults to `InstallEngine.DefaultInstallDir`). Updated `InstallerViewModel.InstallAsync()` and `Finish()` to use `Options.InstallPath` instead of the hardcoded default, wiring the custom path through extraction, shortcuts, file associations, registry entries, and post-install launch. Added 3 new tests.
 
 - **vido-247**: Updated `SeekSliderThumb` style in `PlayerStyles.xaml` — replaced invisible 0px-width transparent grid with a 12px white `Ellipse` matching the `Osr2SliderThumbStyle`. Added `IsMouseOver` trigger that sets the stroke to `AccentBrush`. XAML-only change, no code-behind modifications.

--- a/src/Vido.Setup/Pages/OptionsPage.xaml
+++ b/src/Vido.Setup/Pages/OptionsPage.xaml
@@ -44,19 +44,62 @@
                       Content="Register file associations (.mp4, .avi, .mkv, .mov, .wmv, .flv, .webm)" />
         </StackPanel>
 
-        <!-- Install location (read-only) -->
+        <!-- Install location -->
         <StackPanel Grid.Row="2" VerticalAlignment="Top" Margin="0,20,0,0">
             <TextBlock Text="Install location:"
                        FontSize="12"
                        Foreground="{StaticResource SecondaryForegroundBrush}"
                        Margin="0,0,0,4" />
-            <Border Background="{StaticResource InputBackgroundBrush}"
-                    CornerRadius="3"
-                    Padding="8,6">
-                <TextBlock Text="%LOCALAPPDATA%\Vido"
-                           FontSize="12"
-                           Foreground="{StaticResource DisabledForegroundBrush}" />
-            </Border>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <Border Grid.Column="0"
+                        Background="{StaticResource InputBackgroundBrush}"
+                        CornerRadius="3">
+                    <TextBox x:Name="InstallPathTextBox"
+                             Text="{Binding Options.InstallPath, UpdateSourceTrigger=PropertyChanged}"
+                             Background="Transparent"
+                             BorderThickness="0"
+                             Foreground="{StaticResource PrimaryForegroundBrush}"
+                             FontSize="12"
+                             Padding="8,6"
+                             VerticalContentAlignment="Center" />
+                </Border>
+                <Button Grid.Column="1"
+                        Content="Browse..."
+                        Click="BrowseButton_Click"
+                        Margin="8,0,0,0"
+                        Cursor="Hand">
+                    <Button.Style>
+                        <Style TargetType="Button">
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="Button">
+                                        <Border x:Name="BrowseBorder"
+                                                Background="{StaticResource ButtonDefaultBackgroundBrush}"
+                                                CornerRadius="3"
+                                                Padding="12,6">
+                                            <TextBlock Text="Browse..."
+                                                       FontSize="12"
+                                                       Foreground="White"
+                                                       VerticalAlignment="Center" />
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="IsMouseOver" Value="True">
+                                                <Setter TargetName="BrowseBorder"
+                                                        Property="Background"
+                                                        Value="{StaticResource ButtonBackgroundBrush}" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </Grid>
         </StackPanel>
 
         <!-- Install button -->

--- a/src/Vido.Setup/Pages/OptionsPage.xaml.cs
+++ b/src/Vido.Setup/Pages/OptionsPage.xaml.cs
@@ -1,14 +1,30 @@
+using System.IO;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Vido.Setup.Pages;
 
 /// <summary>
-/// Options page with checkboxes for shortcuts, file associations, and install location display.
+/// Options page with checkboxes for shortcuts, file associations, and install location.
 /// </summary>
 public partial class OptionsPage : UserControl
 {
     public OptionsPage()
     {
         InitializeComponent();
+    }
+
+    private void BrowseButton_Click(object sender, RoutedEventArgs e)
+    {
+        var dialog = new Microsoft.Win32.OpenFolderDialog
+        {
+            Title = "Choose Install Location"
+        };
+
+        if (Directory.Exists(InstallPathTextBox.Text))
+            dialog.InitialDirectory = InstallPathTextBox.Text;
+
+        if (dialog.ShowDialog() == true)
+            InstallPathTextBox.Text = dialog.FolderName;
     }
 }


### PR DESCRIPTION
* Updated OptionsPage.xaml to include an editable TextBox for the install path.
* Added a "Browse..." button to allow users to select a folder using OpenFolderDialog.
* Implemented BrowseButton_Click handler in OptionsPage.xaml.cs to handle folder selection.
* Styled the Browse button to match the existing UI patterns.