### PR TITLE
fix(playlist): delegate shuffle to active provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Vido project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **vido-263**: Fixed shuffle to delegate exclusively to the active playlist provider instead of also building an explorer-based shuffle list. Added early `return` in `OnIsShufflingChanged` after delegating `EnableShuffle()`/`DisableShuffle()` to the provider, preventing `BuildShufflePlaylist()` from creating a duplicate shuffle state from sibling files. Added 3 tests in `PlaylistProviderDelegationTests`.
+
 ### Removed
 - **vido-262**: Removed auto-save playlist feature and `PlaylistAutoSave` setting. Playlists are no longer auto-saved; users must explicitly save via Save or Save As. Removed `AutoSaveIfEnabled()`, `DebounceAutoSaveAsync()`, all 4 call sites in `PlaylistViewModel`, the `playlist.autoSave` store entries, and the "Playlists" settings category.
 

--- a/src/Vido.ViewModels/VideoPlayerViewModel.cs
+++ b/src/Vido.ViewModels/VideoPlayerViewModel.cs
@@ -710,6 +710,8 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
                 _playlistProvider.EnableShuffle();
             else
                 _playlistProvider.DisableShuffle();
+
+            return;
         }
 
         if (value)

--- a/tests/Vido.Tests/PlaylistProviderDelegationTests.cs
+++ b/tests/Vido.Tests/PlaylistProviderDelegationTests.cs
@@ -296,7 +296,78 @@ public class PlaylistProviderDelegationTests : IDisposable
         _playlistProvider.DidNotReceive().GetNextFile();
     }
 
-    // â”€â”€ Helpers â”€â”€
+    // ── Shuffle delegation ──
+
+    /// <summary>
+    /// Verifies that toggling shuffle ON delegates to <see cref="IPlaylistProvider.EnableShuffle"/>
+    /// when the provider is active, and does not build an explorer-based shuffle playlist.
+    /// </summary>
+    [Fact]
+    public async Task ToggleShuffle_DelegatesToProviderAndSkipsExplorerShuffle_WhenProviderActive()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(1));
+
+            await _sut.SetExplorerRootAsync(dir);
+            await _sut.LoadAndPlayAsync(files[0]);
+
+            _playlistProvider.IsActive.Returns(true);
+
+            _sut.IsShuffling = true;
+
+            _playlistProvider.Received(1).EnableShuffle();
+            // Internal shuffle playlist must remain empty (explorer shuffle not built)
+            Assert.Null(_sut.GetShuffleFile(1));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    /// <summary>
+    /// Verifies that toggling shuffle OFF delegates to <see cref="IPlaylistProvider.DisableShuffle"/>
+    /// when the provider is active.
+    /// </summary>
+    [Fact]
+    public void ToggleShuffle_DisablesProviderShuffle_WhenProviderActive()
+    {
+        _playlistProvider.IsActive.Returns(true);
+
+        _sut.IsShuffling = true;
+        _sut.IsShuffling = false;
+
+        _playlistProvider.Received(1).DisableShuffle();
+    }
+
+    /// <summary>
+    /// Verifies that toggling shuffle ON builds the explorer-based shuffle playlist
+    /// when the provider is not active.
+    /// </summary>
+    [Fact]
+    public async Task ToggleShuffle_BuildsExplorerShuffle_WhenProviderNotActive()
+    {
+        var dir = CreateTempVideoDir("a.mp4", "b.mp4", "c.mp4");
+        try
+        {
+            var files = Directory.GetFiles(dir).OrderBy(f => f).ToArray();
+            _engine.Duration.Returns(TimeSpan.FromMinutes(1));
+
+            await _sut.SetExplorerRootAsync(dir);
+            await _sut.LoadAndPlayAsync(files[0]);
+
+            _playlistProvider.IsActive.Returns(false);
+
+            _sut.IsShuffling = true;
+
+            _playlistProvider.DidNotReceive().EnableShuffle();
+            // Internal shuffle playlist should be populated from explorer files
+            Assert.NotNull(_sut.GetShuffleFile(1));
+        }
+        finally { Directory.Delete(dir, true); }
+    }
+
+    // ── Helpers ──
 
     private static string CreateTempVideoDir(params string[] fileNames)
     {


### PR DESCRIPTION
* Fixed shuffle functionality to exclusively delegate to the active playlist provider.
* Added early return in `OnIsShufflingChanged` to prevent duplicate shuffle states.
* Introduced 3 new tests in `PlaylistProviderDelegationTests` to verify shuffle behavior.