### PR TITLE
fix(playlist): wire playlist provider to VideoPlayerViewModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Vido project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **vido-264**: Fixed playlist provider not being wired to `VideoPlayerViewModel` at runtime. The `PlaylistProvider` instance was created in `MainWindow.SetupPlaylists()` after DI resolved `VideoPlayerViewModel` as a singleton, leaving its `_playlistProvider` field permanently null. Added a settable `PlaylistProvider` property (matching the existing `ToastService` pattern) and wired it in `SetupPlaylists()`. This was the root cause of skip/shuffle/media-ended never delegating to the active playlist. Also fixed path case mismatch: added `NormalizePath()` helper using `Path.GetFullPath()` and applied it to all `_vmIndex` and `_pathIndex` operations in `PlaylistViewModel`. Added 2 tests.
 - **vido-263**: Fixed shuffle to delegate exclusively to the active playlist provider instead of also building an explorer-based shuffle list. Added early `return` in `OnIsShufflingChanged` after delegating `EnableShuffle()`/`DisableShuffle()` to the provider, preventing `BuildShufflePlaylist()` from creating a duplicate shuffle state from sibling files. Added 3 tests in `PlaylistProviderDelegationTests`.
 
 ### Removed

--- a/src/Vido.ViewModels/Playlists/PlaylistViewModel.cs
+++ b/src/Vido.ViewModels/Playlists/PlaylistViewModel.cs
@@ -264,7 +264,7 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
         // Only allow video files
         if (!PlaylistProvider.IsVideoFile(filePath)) return;
 
-        if (!_pathIndex.Add(filePath)) return;
+        if (!_pathIndex.Add(NormalizePath(filePath))) return;
 
         _currentPlaylist.Items.Add(new PlaylistItem(filePath));
     }
@@ -279,7 +279,7 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
         ArgumentNullException.ThrowIfNull(filePaths);
 
         var newItems = filePaths
-            .Where(path => PlaylistProvider.IsVideoFile(path) && _pathIndex.Add(path))
+            .Where(path => PlaylistProvider.IsVideoFile(path) && _pathIndex.Add(NormalizePath(path)))
             .Select(path => new PlaylistItem(path))
             .ToList();
 
@@ -324,7 +324,7 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
         if (ReferenceEquals(item, _currentItem))
             CurrentItem = null;
 
-        _pathIndex.Remove(item.FilePath);
+        _pathIndex.Remove(NormalizePath(item.FilePath));
         _currentPlaylist.Items.Remove(item.Model);
     }
 
@@ -702,7 +702,7 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
 
     private void OnVideoLoaded(VideoLoadedEvent e)
     {
-        _vmIndex.TryGetValue(e.FilePath, out var match);
+        _vmIndex.TryGetValue(NormalizePath(e.FilePath), out var match);
 
         CurrentItem = match;
 
@@ -733,8 +733,8 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
                     {
                         var vm = new PlaylistItemViewModel(item);
                         Items.Insert(index++, vm);
-                        _vmIndex[vm.FilePath] = vm;
-                        _pathIndex.Add(vm.FilePath);
+                        _vmIndex[NormalizePath(vm.FilePath)] = vm;
+                        _pathIndex.Add(NormalizePath(vm.FilePath));
                     }
                 }
                 break;
@@ -744,11 +744,12 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
                 {
                     foreach (PlaylistItem item in e.OldItems)
                     {
-                        _pathIndex.Remove(item.FilePath);
+                        var normalizedPath = NormalizePath(item.FilePath);
+                        _pathIndex.Remove(normalizedPath);
 
-                        if (_vmIndex.TryGetValue(item.FilePath, out var vm))
+                        if (_vmIndex.TryGetValue(normalizedPath, out var vm))
                         {
-                            _vmIndex.Remove(item.FilePath);
+                            _vmIndex.Remove(normalizedPath);
                             if (ReferenceEquals(vm, _currentItem))
                                 CurrentItem = null;
 
@@ -796,11 +797,11 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
 
         foreach (var vm in Items)
         {
-            _vmIndex[vm.FilePath] = vm;
-            _pathIndex.Add(vm.FilePath);
+            _vmIndex[NormalizePath(vm.FilePath)] = vm;
+            _pathIndex.Add(NormalizePath(vm.FilePath));
         }
 
-        if (currentFilePath is not null && _vmIndex.TryGetValue(currentFilePath, out var newCurrentItem))
+        if (currentFilePath is not null && _vmIndex.TryGetValue(NormalizePath(currentFilePath), out var newCurrentItem))
         {
             CurrentItem = newCurrentItem;
         }
@@ -859,6 +860,16 @@ public sealed class PlaylistViewModel : INotifyPropertyChanged, IDisposable
         }
 
         return (filePaths, hasUnsupported);
+    }
+
+    /// <summary>
+    /// Normalizes a file path to its canonical form using <see cref="Path.GetFullPath(string)"/>.
+    /// Falls back to the original path if normalization fails (e.g., for network paths).
+    /// </summary>
+    private static string NormalizePath(string path)
+    {
+        try { return Path.GetFullPath(path); }
+        catch { return path; }
     }
 
     private void OnPropertyChanged([CallerMemberName] string? propertyName = null)

--- a/src/Vido.ViewModels/VideoPlayerViewModel.cs
+++ b/src/Vido.ViewModels/VideoPlayerViewModel.cs
@@ -24,7 +24,7 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     private readonly ILogService _logService;
     private readonly ISettingsService _settingsService;
     private readonly IStateService _stateService;
-    private readonly IPlaylistProvider? _playlistProvider;
+    private IPlaylistProvider? _playlistProvider;
     private bool _disposed;
     private bool _isSeeking;
     private double _lastSavedPositionSeconds;
@@ -204,6 +204,16 @@ public partial class VideoPlayerViewModel : ObservableObject, IDisposable
     /// Set after construction by the host since the ViewModel is DI-resolved.
     /// </summary>
     public IToastService? ToastService { get; set; }
+
+    /// <summary>
+    /// Optional playlist provider for playlist-aware skip/next/shuffle behaviour.
+    /// Set after construction by the host since the ViewModel is DI-resolved.
+    /// </summary>
+    public IPlaylistProvider? PlaylistProvider
+    {
+        get => _playlistProvider;
+        set => _playlistProvider = value;
+    }
 
     /// <summary>
     /// Creates the video player view model, wiring up engine events, restoring

--- a/src/Vido.Views/MainWindow.xaml.cs
+++ b/src/Vido.Views/MainWindow.xaml.cs
@@ -1853,6 +1853,8 @@ public partial class MainWindow : Window
             _toastService,
             _playlistProvider);
 
+        _videoPlayerViewModel.PlaylistProvider = _playlistProvider;
+
         // â”€â”€ Wire Status Bar Updates â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
         _playlistVm.PropertyChanged += (_, e) =>
         {

--- a/tests/Vido.Tests/PlaylistViewModelTests.cs
+++ b/tests/Vido.Tests/PlaylistViewModelTests.cs
@@ -768,6 +768,46 @@ public sealed class PlaylistViewModelTests : IDisposable
         Assert.Contains("Playing 1 of 1", _vm.StatusText);
     }
 
+    /// <summary>
+    /// Verifies that VideoLoadedEvent matches playlist item even when file path casing differs,
+    /// keeping the playlist provider active across skip operations.
+    /// </summary>
+    [Fact]
+    public void OnVideoLoaded_MatchesPlaylistItem_WithDifferentCase()
+    {
+        _vm.AddItems([@"C:\Videos\a.mp4", @"C:\Videos\b.mp4"]);
+
+        // Activate provider by simulating play from playlist
+        _playlistProvider.Activate(_vm.CurrentPlaylist.Items, 0);
+
+        // Simulate engine returning the path with different casing
+        _videoLoadedHandler?.Invoke(new VideoLoadedEvent { FilePath = @"c:\videos\B.MP4" });
+
+        Assert.NotNull(_vm.CurrentItem);
+        Assert.Equal("b.mp4", _vm.CurrentItem!.FileName);
+        Assert.True(_playlistProvider.IsActive, "Provider should remain active when file is in playlist");
+    }
+
+    /// <summary>
+    /// Verifies that VideoLoadedEvent deactivates the playlist provider when
+    /// the loaded file is genuinely not in the playlist.
+    /// </summary>
+    [Fact]
+    public void OnVideoLoaded_DeactivatesProvider_WhenFileNotInPlaylist()
+    {
+        _vm.AddItem(@"C:\Videos\a.mp4");
+
+        // Activate provider
+        _playlistProvider.Activate(_vm.CurrentPlaylist.Items, 0);
+        Assert.True(_playlistProvider.IsActive);
+
+        // Load a file that is NOT in the playlist
+        _videoLoadedHandler?.Invoke(new VideoLoadedEvent { FilePath = @"C:\Videos\other.mp4" });
+
+        Assert.Null(_vm.CurrentItem);
+        Assert.False(_playlistProvider.IsActive, "Provider should deactivate for files not in the playlist");
+    }
+
     // ══════════════════════════════════════════════════════════════
     //  HandleFileDrop
     // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
* Fixed playlist provider not being wired at runtime, causing null reference issues.
* Added a settable PlaylistProvider property to VideoPlayerViewModel.
* Normalized file paths in PlaylistViewModel to ensure consistent handling.
* Added tests to verify behavior with different file path casing.