### PR TITLE
feat(vido-280): add Reset button and command for axis settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Vido project will be documented in this file.
 
 ### Added
 
+- **vido-280**: Added per-axis Reset button to axis settings cards. Added `ResetCommand` and `ResetToDefaults()` to `AxisCardViewModel` — resets Min=0, Max=100, Enabled=true, FillMode=None, FillSpeedHz=1.0, SyncWithStroke=true (false for R2), PositionOffset=0. Added Reset button to `AxisCardView.xaml` using `Osr2SmallButtonStyle`. Created `AxisCardViewModelTests.cs` with 7 tests.
+
 - **vido-279**: Skip TWIST (R0) homing on serial connections. Modified `TCodeService.HomeAxes()` to detect serial transport via `_transport is SerialTransportService` and skip R0 axis homing, preserving the device's current physical twist position on reconnect. UDP connections still home all axes including R0. Added `parts.Count > 0` guard before sending. Added 3 tests with `FakeSerialTransport` helper class.
 
 - **vido-278**: Pre-fill the save-profile dialog with an auto-generated default name ("Custom", "Custom1", "Custom2", etc.). Added `GenerateDefaultProfileName()` to `AxisControlViewModel` with case-insensitive duplicate detection. Updated `AxisControlView.OnRequestProfileName` to pass the generated name to `InputDialog`. Added 5 tests.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- App version -->
-    <VidoVersion>0.24.0</VidoVersion>
+    <VidoVersion>0.25.0</VidoVersion>
     <Company>Vido</Company>
     <Product>Vido</Product>
     <Authors>Vido</Authors>

--- a/src/Vido.ViewModels/Osr2Plus/AxisCardViewModel.cs
+++ b/src/Vido.ViewModels/Osr2Plus/AxisCardViewModel.cs
@@ -304,6 +304,9 @@ public class AxisCardViewModel : INotifyPropertyChanged
     /// <summary>Clears the manually loaded funscript from this axis.</summary>
     public ICommand ClearScriptCommand { get; }
 
+    /// <summary>Resets all axis settings to factory defaults.</summary>
+    public ICommand ResetCommand { get; }
+
     // ═══════════════════════════════════════════════════════
     //  Constructor
     // ═══════════════════════════════════════════════════════
@@ -321,6 +324,7 @@ public class AxisCardViewModel : INotifyPropertyChanged
         ToggleExpandCommand = new RelayCommand(() => IsExpanded = !IsExpanded);
         OpenScriptCommand = new RelayCommand(ExecuteOpenScript);
         ClearScriptCommand = new RelayCommand(ExecuteClearScript, () => HasScript);
+        ResetCommand = new RelayCommand(ResetToDefaults);
     }
 
     // ═══════════════════════════════════════════════════════
@@ -382,6 +386,21 @@ public class AxisCardViewModel : INotifyPropertyChanged
 
         // Notify parent to deload the script data and recenter the axis
         ScriptCleared?.Invoke(AxisId);
+    }
+
+    /// <summary>
+    /// Resets all settings for this axis to factory defaults.
+    /// Each property setter raises PropertyChanged and ConfigChanged automatically.
+    /// </summary>
+    private void ResetToDefaults()
+    {
+        Min = 0;
+        Max = 100;
+        Enabled = true;
+        FillMode = AxisFillMode.None;
+        FillSpeedHz = 1.0;
+        SyncWithStroke = AxisId != "R2";
+        PositionOffset = 0;
     }
 
     // ═══════════════════════════════════════════════════════

--- a/src/Vido.Views/Osr2Plus/AxisCardView.xaml
+++ b/src/Vido.Views/Osr2Plus/AxisCardView.xaml
@@ -280,6 +280,14 @@
                         <Border Style="{StaticResource DividerStyle}" />
                     </StackPanel>
 
+                    <!-- ── 5. Reset Button ──────────────────── -->
+                    <Button Content="Reset"
+                            Style="{StaticResource Osr2SmallButtonStyle}"
+                            Command="{Binding ResetCommand}"
+                            ToolTip="Reset all settings for this axis to defaults"
+                            HorizontalAlignment="Left"
+                            Margin="0,8,0,0" />
+
                 </StackPanel>
             </StackPanel>
         </Grid>

--- a/tests/Vido.Tests/AxisCardViewModelTests.cs
+++ b/tests/Vido.Tests/AxisCardViewModelTests.cs
@@ -1,0 +1,168 @@
+using System.ComponentModel;
+using Vido.Core.Models.Osr2Plus;
+using Vido.Services.Osr2Plus;
+using Vido.ViewModels.Osr2Plus;
+using Xunit;
+
+namespace Vido.Tests;
+
+/// <summary>
+/// Tests for <see cref="AxisCardViewModel"/> reset functionality.
+/// </summary>
+public class AxisCardViewModelTests : IDisposable
+{
+    private readonly InterpolationService _interpolation = new();
+    private readonly TCodeService _tcode;
+
+    public AxisCardViewModelTests()
+    {
+        _tcode = new TCodeService(_interpolation);
+    }
+
+    public void Dispose()
+    {
+        _tcode.Dispose();
+    }
+
+    // ──────────────────────────────────────────────
+    //  Helper methods
+    // ──────────────────────────────────────────────
+
+    private static AxisConfig MakeConfig(string id, string name, int min = 50, int max = 80,
+        bool enabled = false, AxisFillMode fillMode = AxisFillMode.Sine,
+        double fillSpeedHz = 2.5, bool syncWithStroke = false, double positionOffset = 10)
+    {
+        return new AxisConfig
+        {
+            Id = id, Name = name, Type = id == "L0" ? "linear" : "rotation",
+            Min = min, Max = max, Enabled = enabled,
+            FillMode = fillMode, FillSpeedHz = fillSpeedHz,
+            SyncWithStroke = syncWithStroke, PositionOffset = positionOffset
+        };
+    }
+
+    private AxisCardViewModel MakeVm(string id, string name) =>
+        new(MakeConfig(id, name), _tcode);
+
+    // ═══════════════════════════════════════════════
+    //  ResetToDefaults
+    // ═══════════════════════════════════════════════
+
+    [Fact]
+    public void ResetToDefaults_L0_SetsCorrectValues()
+    {
+        var vm = MakeVm("L0", "Stroke");
+        vm.ResetCommand.Execute(null);
+
+        Assert.Equal(0, vm.Min);
+        Assert.Equal(100, vm.Max);
+        Assert.True(vm.Enabled);
+        Assert.Equal(AxisFillMode.None, vm.FillMode);
+        Assert.Equal(1.0, vm.FillSpeedHz);
+        Assert.True(vm.SyncWithStroke);
+        Assert.Equal(0, vm.PositionOffset);
+    }
+
+    [Fact]
+    public void ResetToDefaults_R0_SetsCorrectValues()
+    {
+        var vm = MakeVm("R0", "Twist");
+        vm.ResetCommand.Execute(null);
+
+        Assert.Equal(0, vm.Min);
+        Assert.Equal(100, vm.Max);
+        Assert.True(vm.Enabled);
+        Assert.Equal(AxisFillMode.None, vm.FillMode);
+        Assert.Equal(1.0, vm.FillSpeedHz);
+        Assert.True(vm.SyncWithStroke);
+        Assert.Equal(0, vm.PositionOffset);
+    }
+
+    [Fact]
+    public void ResetToDefaults_R1_SetsCorrectValues()
+    {
+        var vm = MakeVm("R1", "Roll");
+        vm.ResetCommand.Execute(null);
+
+        Assert.Equal(0, vm.Min);
+        Assert.Equal(100, vm.Max);
+        Assert.True(vm.Enabled);
+        Assert.Equal(AxisFillMode.None, vm.FillMode);
+        Assert.Equal(1.0, vm.FillSpeedHz);
+        Assert.True(vm.SyncWithStroke);
+        Assert.Equal(0, vm.PositionOffset);
+    }
+
+    [Fact]
+    public void ResetToDefaults_R2_SyncWithStrokeFalse()
+    {
+        var vm = MakeVm("R2", "Pitch");
+        vm.ResetCommand.Execute(null);
+
+        Assert.Equal(0, vm.Min);
+        Assert.Equal(100, vm.Max);
+        Assert.True(vm.Enabled);
+        Assert.Equal(AxisFillMode.None, vm.FillMode);
+        Assert.Equal(1.0, vm.FillSpeedHz);
+        Assert.False(vm.SyncWithStroke);
+        Assert.Equal(0, vm.PositionOffset);
+    }
+
+    [Fact]
+    public void ResetToDefaults_FromModifiedState_RestoresDefaults()
+    {
+        var vm = MakeVm("R1", "Roll");
+
+        // Verify non-default state
+        Assert.Equal(50, vm.Min);
+        Assert.Equal(80, vm.Max);
+        Assert.False(vm.Enabled);
+        Assert.Equal(AxisFillMode.Sine, vm.FillMode);
+        Assert.Equal(2.5, vm.FillSpeedHz);
+        Assert.False(vm.SyncWithStroke);
+        Assert.Equal(10, vm.PositionOffset);
+
+        vm.ResetCommand.Execute(null);
+
+        Assert.Equal(0, vm.Min);
+        Assert.Equal(100, vm.Max);
+        Assert.True(vm.Enabled);
+        Assert.Equal(AxisFillMode.None, vm.FillMode);
+        Assert.Equal(1.0, vm.FillSpeedHz);
+        Assert.True(vm.SyncWithStroke);
+        Assert.Equal(0, vm.PositionOffset);
+    }
+
+    [Fact]
+    public void ResetToDefaults_RaisesConfigChanged()
+    {
+        var vm = MakeVm("L0", "Stroke");
+        var configChangedCount = 0;
+        vm.ConfigChanged += () => configChangedCount++;
+
+        vm.ResetCommand.Execute(null);
+
+        Assert.True(configChangedCount > 0, "ConfigChanged should fire at least once during reset");
+    }
+
+    [Fact]
+    public void ResetToDefaults_RaisesPropertyChanged()
+    {
+        var vm = MakeVm("R0", "Twist");
+        var changedProperties = new List<string>();
+        vm.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != null) changedProperties.Add(e.PropertyName);
+        };
+
+        vm.ResetCommand.Execute(null);
+
+        Assert.Contains(nameof(AxisCardViewModel.Min), changedProperties);
+        Assert.Contains(nameof(AxisCardViewModel.Max), changedProperties);
+        Assert.Contains(nameof(AxisCardViewModel.Enabled), changedProperties);
+        Assert.Contains(nameof(AxisCardViewModel.FillMode), changedProperties);
+        Assert.Contains(nameof(AxisCardViewModel.FillSpeedHz), changedProperties);
+        Assert.Contains(nameof(AxisCardViewModel.SyncWithStroke), changedProperties);
+        Assert.Contains(nameof(AxisCardViewModel.PositionOffset), changedProperties);
+    }
+}


### PR DESCRIPTION
* Implemented ResetCommand in AxisCardViewModel to reset axis settings to factory defaults.
* Added Reset button in AxisCardView.xaml with appropriate styling and tooltip.
* Created AxisCardViewModelTests.cs to test ResetToDefaults functionality with multiple test cases.